### PR TITLE
Fix bug in Layer::getIntersection which could cause an infinite loop

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -81,6 +81,7 @@
                     }
                     // if no shape, and no antialiased pixel, we should end searching 
                     if (continueSearch) {
+                        continueSearch = false;
                         spiralSearchDistance += 1;
                     } else {
                         return;


### PR DESCRIPTION
This fixes a bug in getIntersection. If you looked at it before, if "continueSearch" is ever set to true, unless it finds another shape on a subsequent loop (not guaranteed) it can end up in an infinite loop.

I believe the solution is to set "continueSearch" to false before or after "spiralSearchDistance += 1". This change helped for me. 

I do notice that even with the fix in place, this loop runs many, many times before finding a result when this antialiased condition is met, it leads to slow down in my app and I'll personally be disabling it.