### PR TITLE
Enable devicePixelRatio for desktop browsers

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -2,12 +2,7 @@
     // calculate pixel ratio
     var canvas = Konva.Util.createCanvasElement(),
         context = canvas.getContext('2d'),
-        // if using a mobile device, calculate the pixel ratio.  Otherwise, just use
-        // 1.  For desktop browsers, if the user has zoom enabled, it affects the pixel ratio
-        // and causes artifacts on the canvas.  As of 02/26/2014, there doesn't seem to be a way
-        // to reliably calculate the browser zoom for modern browsers, which is why we just set
-        // the pixel ratio to 1 for desktops
-        _pixelRatio = Konva.UA.mobile ? (function() {
+        _pixelRatio = (function() {
             var devicePixelRatio = window.devicePixelRatio || 1,
             backingStoreRatio = context.webkitBackingStorePixelRatio
                 || context.mozBackingStorePixelRatio
@@ -16,7 +11,7 @@
                 || context.backingStorePixelRatio
                 || 1;
             return devicePixelRatio / backingStoreRatio;
-        })() : 1;
+        })();
 
     /**
      * Canvas Renderer constructor


### PR DESCRIPTION
This PR is a part of issue #43 and it needs testing because I only checked it on Safari and FF / Mac.