### PR TITLE
Fix attrs initialization regression

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -621,7 +621,7 @@
 
             if(config) {
                 for(key in config) {
-                    if (key === CHILDREN || config[key] instanceof Konva.Node) {
+                    if (key === CHILDREN) {
 
                     }
                     else {


### PR DESCRIPTION
Don't know who decided that it's a good idea to silently ignore attributes that contain nodes. Cross-reference against KineticJS shows slightly different picture.

https://github.com/ericdrowell/KineticJS/blob/master/src/Node.js#L542

I have a couple of Q regarding that strange piece of code:

1. What was the original intent? 
2. Why was children key ignored instead of presumably being used to add child nodes into newly created node? 
3. Why was type check for `Konva.Node` introduced too?

If none of that serve any purpose then this PR fixes issue #41.