### PR TITLE
Fix hit canvas pixel ratio

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -188,7 +188,6 @@
                 height: height
             }),
             cachedHitCanvas = new Konva.HitCanvas({
-                pixelRatio : 1,
                 width: width,
                 height: height
             }),
@@ -314,13 +313,14 @@
         },
         _drawCachedHitCanvas: function(context) {
             var cachedCanvas = this._cache.canvas,
-                hitCanvas = cachedCanvas.hit;
+                hitCanvas = cachedCanvas.hit,
+                ratio = hitCanvas.pixelRatio;
             context.save();
             context.translate(
                 this._cache.canvas.x,
                 this._cache.canvas.y
             );
-            context.drawImage(hitCanvas._canvas, 0, 0);
+            context.drawImage(hitCanvas._canvas, 0, 0, hitCanvas.width / ratio, hitCanvas.height / ratio);
             context.restore();
         },
         _getCachedSceneCanvas: function() {

--- a/src/Node.js
+++ b/src/Node.js
@@ -188,6 +188,7 @@
                 height: height
             }),
             cachedHitCanvas = new Konva.HitCanvas({
+                pixelRatio: 1,
                 width: width,
                 height: height
             }),
@@ -313,14 +314,13 @@
         },
         _drawCachedHitCanvas: function(context) {
             var cachedCanvas = this._cache.canvas,
-                hitCanvas = cachedCanvas.hit,
-                ratio = hitCanvas.pixelRatio;
+                hitCanvas = cachedCanvas.hit;
             context.save();
             context.translate(
                 this._cache.canvas.x,
                 this._cache.canvas.y
             );
-            context.drawImage(hitCanvas._canvas, 0, 0, hitCanvas.width / ratio, hitCanvas.height / ratio);
+            context.drawImage(hitCanvas._canvas, 0, 0);
             context.restore();
         },
         _getCachedSceneCanvas: function() {

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -393,7 +393,6 @@
                 height = sceneCanvas.getHeight(),
                 hitWidth = hitCanvas.getWidth(),
                 hitHeight = hitCanvas.getHeight(),
-                pixelRatio = sceneCanvas.pixelRatio,
                 hitImageData, hitData, len, rgbColorKey, i, alpha;
 
             hitContext.clear();

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -391,21 +391,23 @@
                 hitContext = hitCanvas.getContext(),
                 width = sceneCanvas.getWidth(),
                 height = sceneCanvas.getHeight(),
-                sceneImageData, sceneData, hitImageData, hitData, len, rgbColorKey, i, alpha;
+                hitWidth = hitCanvas.getWidth(),
+                hitHeight = hitCanvas.getHeight(),
+                pixelRatio = sceneCanvas.pixelRatio,
+                hitImageData, hitData, len, rgbColorKey, i, alpha;
 
             hitContext.clear();
+            hitContext.drawImage(sceneCanvas._canvas, 0, 0, hitWidth, hitHeight);
 
             try {
-                sceneImageData = sceneContext.getImageData(0, 0, width, height);
-                sceneData = sceneImageData.data;
-                hitImageData = hitContext.getImageData(0, 0, width, height);
+                hitImageData = hitContext.getImageData(0, 0, hitWidth, hitHeight);
                 hitData = hitImageData.data;
-                len = sceneData.length;
+                len = hitData.length;
                 rgbColorKey = Konva.Util._hexToRgb(this.colorKey);
 
                 // replace non transparent pixels with color key
                 for(i = 0; i < len; i += 4) {
-                    alpha = sceneData[i + 3];
+                    alpha = hitData[i + 3];
                     if (alpha > threshold) {
                         hitData[i] = rgbColorKey.r;
                         hitData[i + 1] = rgbColorKey.g;

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -386,11 +386,8 @@
             var threshold = alphaThreshold || 0,
                 cachedCanvas = this._cache.canvas,
                 sceneCanvas = this._getCachedSceneCanvas(),
-                sceneContext = sceneCanvas.getContext(),
                 hitCanvas = cachedCanvas.hit,
                 hitContext = hitCanvas.getContext(),
-                width = sceneCanvas.getWidth(),
-                height = sceneCanvas.getHeight(),
                 hitWidth = hitCanvas.getWidth(),
                 hitHeight = hitCanvas.getHeight(),
                 hitImageData, hitData, len, rgbColorKey, i, alpha;


### PR DESCRIPTION
The code that handles hit context processing does not take into account pixel ratio which results in invalid hit map because `getImageData` returns more pixels than hit context can possibly hold because it is always created with pixelRatio = 1.

We better have smaller hit maps to save some memory but I could not find an easy way to tackle this. 

I've been looking for solution using `drawImage` on top of hit canvas using a replacement fill color but I couldn't find support for that in current Canvas API implementation, that would be the cheapest way, otherwise we have to loop through hundreds of thousands of bytes and replace colors manually. CPU wise it is probably cheaper to have larger hit map than to resample returned data set or use a temporary canvas for that.

https://github.com/konvajs/konva/blob/master/src/Shape.js#L399

![mask3](https://cloud.githubusercontent.com/assets/704044/7121232/5e1448f0-e213-11e4-96bd-3fb9a0856ab2.jpg)

Legend: 

1. red mask is what we have now
2. green mask is a fixed hit map (this PR)
