### PR TITLE
Blit directly to hitCanvas and avoid using temporary canvas

### DIFF
--- a/src/Shape.js
+++ b/src/Shape.js
@@ -386,47 +386,32 @@
             var threshold = alphaThreshold || 0,
                 cachedCanvas = this._cache.canvas,
                 sceneCanvas = this._getCachedSceneCanvas(),
-                sceneContext = sceneCanvas.getContext(),
                 hitCanvas = cachedCanvas.hit,
                 hitContext = hitCanvas.getContext(),
-                width = sceneCanvas.getWidth(),
-                height = sceneCanvas.getHeight(),
-                sceneImageData, sceneData, hitImageData, hitData, len, rgbColorKey, i, alpha;
+                hitWidth = hitCanvas.getWidth(),
+                hitHeight = hitCanvas.getHeight(),
+                hitImageData, hitData, len, rgbColorKey, i, alpha;
 
             hitContext.clear();
-            var ratio = sceneCanvas.pixelRatio;
-            var hitWidth = Math.floor(width / ratio);
-            var hitHeight = Math.floor(height / ratio);
+            hitContext.drawImage(sceneCanvas._canvas, 0, 0, hitWidth, hitHeight);
 
             try {
-                // if pixelRatio > 1 we need to redraw scene canvas into temp canvas
-                // with pixelRatio = 1 to have the same dimension as hitCanvas
-                if (ratio !== 1) {
-                    var tempCanvas = new Konva.SceneCanvas({
-                        width : hitWidth,
-                        height : hitHeight,
-                        pixelRatio : 1
-                    });
-                    tempCanvas.getContext().drawImage(sceneCanvas._canvas, 0, 0, hitWidth, hitHeight);
-                    sceneImageData = tempCanvas.getContext().getImageData(0, 0, hitWidth, hitHeight);
-                    sceneData = sceneImageData.data;
-                } else {
-                    sceneImageData = sceneContext.getImageData(0, 0, width, height);
-                    sceneData = sceneImageData.data;
-                }
                 hitImageData = hitContext.getImageData(0, 0, hitWidth, hitHeight);
                 hitData = hitImageData.data;
-                len = sceneData.length;
+                len = hitData.length;
                 rgbColorKey = Konva.Util._hexToRgb(this.colorKey);
 
                 // replace non transparent pixels with color key
                 for(i = 0; i < len; i += 4) {
-                    alpha = sceneData[i + 3];
+                    alpha = hitData[i + 3];
                     if (alpha > threshold) {
                         hitData[i] = rgbColorKey.r;
                         hitData[i + 1] = rgbColorKey.g;
                         hitData[i + 2] = rgbColorKey.b;
                         hitData[i + 3] = 255;
+                    }
+                    else {
+                        hitData[i + 3] = 0;
                     }
                 }
                 hitContext.putImageData(hitImageData, 0, 0);


### PR DESCRIPTION
Take 2:

1. Blit directly to hit canvas, work only with hit canvas buffer. No need to create an ImageData buffer for sceneCanvas. It's cheaper to work with single buffer. I think it's pretty expensive to allocate a temp canvas as opposed to using the same hitCanvas.

2. Reset Konva.pixelRatio to default undefined value in Stage tests.