### PR TITLE
Fix Stage#toDataURL to produce retina snapshots

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1391,7 +1391,7 @@
                 canvas = new Konva.SceneCanvas({
                     width: config.width || this.getWidth() || (stage ? stage.getWidth() : 0),
                     height: config.height || this.getHeight() || (stage ? stage.getHeight() : 0),
-                    pixelRatio: 1
+                    pixelRatio: config.pixelRatio
                 }),
                 context = canvas.getContext();
 

--- a/src/Node.js
+++ b/src/Node.js
@@ -307,9 +307,9 @@
             );
 
             var cacheCanvas = this._getCachedSceneCanvas();
-            var ratio = context.canvas.pixelRatio;
+            var ratio = cacheCanvas.pixelRatio;
 
-            context.drawImage(cacheCanvas._canvas, 0, 0, cacheCanvas.width / ratio, cacheCanvas.height /ratio);
+            context.drawImage(cacheCanvas._canvas, 0, 0, cacheCanvas.width / ratio, cacheCanvas.height / ratio);
             context.restore();
         },
         _drawCachedHitCanvas: function(context) {

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -235,7 +235,7 @@
                 canvas = new Konva.SceneCanvas({
                     width: config.width || this.getWidth(),
                     height: config.height || this.getHeight(),
-                    pixelRatio: 1
+                    pixelRatio: config.pixelRatio
                 }),
                 _context = canvas.getContext()._context,
                 layers = this.children;
@@ -246,11 +246,14 @@
 
             function drawLayer(n) {
                 var layer = layers[n],
-                    layerUrl = layer.toDataURL(),
+                    layerUrl = layer.toDataURL({
+                        pixelRatio: config.pixelRatio
+                    }),
+                    pixelRatio = canvas.pixelRatio,
                     imageObj = new Konva.window.Image();
 
                 imageObj.onload = function() {
-                    _context.drawImage(imageObj, 0, 0);
+                    _context.drawImage(imageObj, 0, 0, imageObj.width / pixelRatio, imageObj.height / pixelRatio);
 
                     if(n < layers.length - 1) {
                         drawLayer(n + 1);


### PR DESCRIPTION
`Stage#toDataURL()` creates a canvas with pixelRatio = 1. As you can see if context.canvas comes with pixelRatio = 1 and cacheCanvas has a ratio of 2, then we have twice larger image on output.

Fixes issue discussed in #58.

Screenshot:

![screenshot 2015-04-16 17 13 45](https://cloud.githubusercontent.com/assets/704044/7184187/1d689c2a-e45c-11e4-96b8-39b684aa774c.png)

The bottom tiger is a bit blurry, that's because it's 1x scale which toDataURL produces. I guess we can tackle this issue in some other PR.