### PR TITLE
Fix color alpha rounding bug. (Fixes #67)

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -156,7 +156,7 @@
                             Math.round(start.r + diff.r * i) + ',' +
                             Math.round(start.g + diff.g * i) + ',' +
                             Math.round(start.b + diff.b * i) + ',' +
-                            Math.round(start.a + diff.a * i) + ')';
+                            (start.a + diff.a * i) + ')';
                 } else {
                     newVal = start + (diff * i);
                 }

--- a/test/unit/Tween-test.js
+++ b/test/unit/Tween-test.js
@@ -156,17 +156,25 @@ suite('Tween', function() {
         layer.add(circle);
         stage.add(layer);
 
-        var c = Konva.Util.colorToRGBA('green');
+        var duration = 0.1;
+        var c = Konva.Util.colorToRGBA('rgba(0,255,0,0.5)');
         var endFill = 'rgba(' + c.r + ',' + c.g + ',' + c.b + ',' + c.a + ')';
+        var midFill = 'rgba(128,128,0,0.75)';
+
         var tween = new Konva.Tween({
             node: circle,
-            duration: 0.1,
+            duration: duration,
             fill : endFill,
             onFinish : function() {
                 assert.equal(endFill, circle.fill());
                 done();
             }
         });
+
+        tween.seek(duration * 0.5);
+        assert.equal(midFill, circle.fill());
+
+        tween.seek(0);
         tween.play();
     });
 


### PR DESCRIPTION
Unlike color components range [0..255], alpha component uses [0..1] range. I believe the use of `Math.round` is a typo. Parentheses in code left to avoid string concatenation problems.