### PR TITLE
Config to not export invisible layers

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -223,6 +223,7 @@
          * @param {Number} [config.quality] jpeg quality.  If using an "image/jpeg" mimeType,
          *  you can specify the quality from 0 to 1, where 0 is very poor quality and 1
          *  is very high quality
+         * @param {Boolean} [config.exportVisibleLayersOnly=false] If set to true, the stage will only export a layer which is visible.
          */
         toDataURL: function(config) {
             config = config || {};
@@ -231,6 +232,7 @@
                 quality = config.quality || null,
                 x = config.x || 0,
                 y = config.y || 0,
+                exportVisibleLayersOnly = !!config.exportVisibleLayersOnly || false,
                 canvas = new Konva.SceneCanvas({
                     width: config.width || this.getWidth(),
                     height: config.height || this.getHeight(),
@@ -245,6 +247,10 @@
 
 
             layers.each(function(layer) {
+                if (exportVisibleLayersOnly && !layer.isVisible()) {
+                    return;
+                }
+
                 var width = layer.getCanvas().getWidth();
                 var height = layer.getCanvas().getHeight();
                 var ratio = layer.getCanvas().getPixelRatio();

--- a/test/unit/Stage-test.js
+++ b/test/unit/Stage-test.js
@@ -572,6 +572,29 @@ suite('Stage', function() {
         assert.equal(stage.toDataURL(), layer.toDataURL());
     });
 
+    test('toDataUrl skips hidden layers', function () {
+        var stage = addStage();
+        var layer = new Konva.Layer();
+        var circle = new Konva.Circle({
+            x: stage.width() / 2,
+            y: stage.height() / 2,
+            fill: 'red',
+            radius: 50
+        });
+        layer.add(circle);
+        stage.add(layer);
+
+        var layerDataUrl = layer.toDataURL();
+
+        layer.setVisible(false);
+
+        var stageDataUrl = stage.toDataURL({
+            exportVisibleLayersOnly: true
+        });
+
+        assert.notEqual(stageDataUrl, layerDataUrl);
+    });
+
     test('check hit graph with stage listeting property', function() {
       var stage = addStage();
       var layer = new Konva.Layer();


### PR DESCRIPTION
I recently had the problem, that I had to export a stage which has some invisible layers. Within the stage export, the invisible layers are still drawn.

With this pull request I want to add an option to the stage's "toDataURL" function, which will, when set to true, not export invisible layers.
The option is set to false per default to not break existing applications using Konva. 