### PR TITLE
added rotation as property since rotationDeg is obsolete

### DIFF
--- a/resources/konva.d.ts
+++ b/resources/konva.d.ts
@@ -78,6 +78,7 @@ declare module Konva {
         scale?: Vector2d;
         scaleX? : number;
         scaleY? : number;
+        rotation?: number;
         rotationDeg?: number;
         offset?: Vector2d;
         offsetX? : number;


### PR DESCRIPTION
Only a tiny change but since using rotationDeg results in undesirable warnings, one should rather use rotation and that obviously requires a corresponding property in the typescript typings.

We could additionally remove the obsolete rotationDeg from these typings but since it still works (albeit with warnings), I guess that would be premature.