### PR TITLE
quick fix for typings removing default export

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -1,4 +1,4 @@
-declare module Konva {
+declare module "Konva" {
 
     var pixelRatio : number;
     var dragDistance: number;
@@ -53,14 +53,14 @@ declare module Konva {
     }
 
     export class Animation {
-        constructor(func: Function, layers?: Konva.Layer[]);
-        constructor(func: Function, layer?: Konva.Layer);
+        constructor(func: Function, layers?: Layer[]);
+        constructor(func: Function, layer?: Layer);
 
-        addLayer(layer: Konva.Layer) : boolean;
-        getLayers() : Konva.Layer[];
+        addLayer(layer: Layer) : boolean;
+        getLayers() : Layer[];
         isRunning() : boolean;
-        setLayers(layers : Konva.Layer[]) : Animation;
-        setLayers(layer : Konva.Layer) : Animation;
+        setLayers(layers : Layer[]) : Animation;
+        setLayers(layer : Layer) : Animation;
         start() : Animation;
         stop() : Animation;
     }
@@ -511,7 +511,7 @@ declare module Konva {
         clearTrace(): void;
         fillShape(shape: Shape): void;
         fillStrokeShape(shape: Shape): void;
-        getCanvas() : Konva.Canvas;
+        getCanvas() : Canvas;
         getTrace(relaxed: boolean): string;
         reset(): void;
         moveTo(x : number, y : number) : void;
@@ -802,7 +802,7 @@ declare module Konva {
     class Collection {
         [i : number] : any;
         static toCollection(arr: any[]): Collection;
-        each(f: (el : Konva.Node) => void): void;
+        each(f: (el : Node) => void): void;
         toArray() : any[];
         length: number;
     }
@@ -826,5 +826,3 @@ declare module Konva {
     }
 
 }
-
-export default Konva;


### PR DESCRIPTION
Made it possible to use typings pretty easily with:
```typescript
import * as Konva from "Konva";
```

I still think the typings need work, but this is a quick fix for now.