### PR TITLE
Wrap export = in declare module.

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -828,4 +828,6 @@ declare module Konva {
     }
 }
 
-export = Konva;
+declare module "konva" {
+    export = Konva;
+}


### PR DESCRIPTION
This allows Konva to be used in files that don't import "konva", for the purpose of code like "var x: Konva.Path". This reduces the number of imports that only exist for typings purposes.