### PR TITLE
add lineDashOffset support to context

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -51,6 +51,7 @@
     'shadowOffsetX',
     'shadowOffsetY',
     'lineCap',
+    'lineDashOffset',
     'lineJoin',
     'lineWidth',
     'miterLimit',

--- a/src/Context.js
+++ b/src/Context.js
@@ -600,6 +600,7 @@
         this._applyLineCap(shape);
         if (dash && shape.dashEnabled()) {
           this.setLineDash(dash);
+          this.setAttr('lineDashOffset', shape.dashOffset());
         }
 
         this.setAttr('lineWidth', shape.strokeWidth());

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -713,6 +713,21 @@
      *  line.dash([10, 20, 0.001, 20]);
      */
 
+  Konva.Factory.addGetterSetter(Konva.Shape, 'dashOffset', 0);
+
+  /**
+     * get/set dash offset for stroke.
+     * @name dash
+     * @method
+     * @memberof Konva.Shape.prototype
+     * @param {Number} dash offset
+     * @returns {Number}
+     * @example
+     *  // apply dashed stroke that is 10px long and 5 pixels apart with an offset of 5px
+     *  line.dash([10, 5]);
+     *  line.dashOffset(5);
+     */
+
   Konva.Factory.addGetterSetter(Konva.Shape, 'shadowColor');
 
   /**

--- a/test/unit/Context-test.js
+++ b/test/unit/Context-test.js
@@ -44,6 +44,7 @@ suite('Context', function() {
     'shadowOffsetX',
     'shadowOffsetY',
     'lineCap',
+    'lineDashOffset',
     'lineJoin',
     'lineWidth',
     'miterLimit',

--- a/test/unit/Shape-test.js
+++ b/test/unit/Shape-test.js
@@ -896,6 +896,7 @@ suite('Shape', function() {
     assert.equal(shape.strokeEnabled(), true);
     assert.equal(shape.shadowEnabled(), true);
     assert.equal(shape.dashEnabled(), true);
+    assert.equal(shape.dashOffset(), 0);
     assert.equal(shape.strokeScaleEnabled(), true);
     assert.equal(shape.fillPriority(), 'color');
     assert.equal(shape.fillPatternOffsetX(), 0);


### PR DESCRIPTION
This adds support for `lineDashOffset` to the context and a `dashOffset` property to `Shape`, which is useful to create _marching ants_ animations or animated lines.
Fixes #212.

Browser compatibility [looks pretty good](https://developer.mozilla.org/de/docs/Web/API/CanvasRenderingContext2D/lineDashOffset#Browser_compatibility).