### PR TITLE
use transform safe offsetX instead of clientX

### DIFF
--- a/konva.js
+++ b/konva.js
@@ -10393,13 +10393,13 @@
         if (evt.touches.length > 0) {
           var touch = evt.touches[0];
           // get the information for finger #1
-          x = touch.clientX - contentPosition.left;
-          y = touch.clientY - contentPosition.top;
+          x = touch.offsetX;
+          y = touch.offsetY;
         }
       } else {
         // mouse events
-        x = evt.clientX - contentPosition.left;
-        y = evt.clientY - contentPosition.top;
+        x = evt.offsetX;
+        y = evt.offsetY;
       }
       if (x !== null && y !== null) {
         this.pointerPos = {

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -705,13 +705,13 @@
         if (evt.touches.length > 0) {
           var touch = evt.touches[0];
           // get the information for finger #1
-          x = touch.clientX - contentPosition.left;
-          y = touch.clientY - contentPosition.top;
+          x = touch.offsetX;
+          y = touch.offsetY;
         }
       } else {
         // mouse events
-        x = evt.clientX - contentPosition.left;
-        y = evt.clientY - contentPosition.top;
+        x = evt.offsetX;
+        y = evt.offsetY;
       }
       if (x !== null && y !== null) {
         this.pointerPos = {


### PR DESCRIPTION
clientX is not desirable for two reasons.

1. if a css transform is applied, the coordinates may not be correct
2. clientX needs to take the element position into account to calculate a relative position

offsetX/Y avoids both of these problems