### PR TITLE
Update Arc definition

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -561,16 +561,23 @@ declare module Konva {
         outerRadius(outerRadius: number): Ring;
     }
 
-    interface ArcConfig extends RingConfig {
+    interface ArcConfig extends ShapeConfig {
         angle: number;
+        innerRadius: number;
+        outerRadius: number;
+        clockwise?: boolean;
     }
 
-    class Arc extends Ring {
+    class Arc extends Shape {
         constructor(ArcConfig: ArcConfig);
         angle(): number;
         angle(angle: number): Ring;
         clockwise(): boolean;
         clockwise(clockwise: boolean): Arc;
+        innerRadius(): number;
+        innerRadius(innerRadius: number): Arc;
+        outerRadius(): number;
+        outerRadius(outerRadius: number): Arc;
     }
 
     interface CircleConfig extends ShapeConfig {

--- a/konva.d.ts
+++ b/konva.d.ts
@@ -555,8 +555,6 @@ declare module Konva {
 
     class Ring extends Shape {
         constructor(RingConfig: RingConfig);
-        angle(): number;
-        angle(angle: number): Ring;
         innerRadius(): number;
         innerRadius(innerRadius: number): Ring;
         outerRadius(): number;
@@ -567,8 +565,10 @@ declare module Konva {
         angle: number;
     }
 
-    class Arc extends Shape {
+    class Arc extends Ring {
         constructor(ArcConfig: ArcConfig);
+        angle(): number;
+        angle(angle: number): Ring;
         clockwise(): boolean;
         clockwise(clockwise: boolean): Arc;
     }


### PR DESCRIPTION
Arc class need to extend Ring in order to be able to access inner and outer radius, and angle method is in Arc class not in Ring.