### PR TITLE
fix double click

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -529,6 +529,7 @@
         this._setPointerPosition(evt);
         var shape = this.getIntersection(this.getPointerPosition()),
           clickStartShape = this.clickStartShape,
+          clickEndShape = this.clickEndShape,
           fireDblClick = false,
           dd = Konva.DD;
 
@@ -547,6 +548,7 @@
         }, Konva.dblClickWindow);
 
         if (shape && shape.isListening()) {
+          this.clickEndShape = shape;
           shape._fireAndBubble(MOUSEUP, { evt: evt });
 
           // detect if click or double click occurred
@@ -557,7 +559,11 @@
           ) {
             shape._fireAndBubble(CLICK, { evt: evt });
 
-            if (fireDblClick) {
+            if (
+              fireDblClick &&
+              clickEndShape &&
+              clickEndShape._id === shape._id
+            ) {
               shape._fireAndBubble(DBL_CLICK, { evt: evt });
             }
           }

--- a/test/functional/MouseEvents-test.js
+++ b/test/functional/MouseEvents-test.js
@@ -1413,6 +1413,72 @@ suite('MouseEvents', function() {
   });
 
   // ======================================================
+  test('test dblclick to a wrong target', function () {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+    stage.add(layer);
+
+    var leftRect = new Konva.Rect({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      fill: 'red'
+    });
+    layer.add(leftRect);
+
+    var rightRect = new Konva.Rect({
+      x: 100,
+      y: 0,
+      width: 100,
+      height: 100,
+      fill: 'blue'
+    });
+    layer.add(rightRect);
+
+    stage.draw();
+
+    var leftRectSingleClick = 0;
+    var rightRectSingleClick = 0;
+    var rightRectDblClick = 0;
+
+    leftRect.on('click', function () {
+      leftRectSingleClick++;
+    });
+    rightRect.on('click', function () {
+      rightRectSingleClick++;
+    });
+    rightRect.on('dblclick', function () {
+      rightRectDblClick++;
+    });
+
+    stage.simulateMouseDown({
+      x: 50,
+      y: 50
+    });
+    stage.simulateMouseUp({
+      x: 50,
+      y: 50
+    });
+    assert.equal(leftRectSingleClick, 1, 'leftRect trigger a click');
+
+    stage.simulateMouseDown({
+      x: 150,
+      y: 50
+    });
+    stage.simulateMouseUp({
+      x: 150,
+      y: 50
+    });
+    assert.equal(rightRectSingleClick, 1, 'rightRect trigger a click');
+    assert.equal(
+      rightRectDblClick,
+      0,
+      'rightRect dblClick should not trigger'
+    );
+  });
+
+  // ======================================================
   test('test mouseleave + mouseenter with deep nesting', function() {
     var stage = addStage();
     var layer = new Konva.Layer();


### PR DESCRIPTION
Fix #252 

Hi. I review the code about double click. I found there is no compare the double click target to the last mouseup target.

Sorry for my poor English. I wish I could help.

Codes in `src/Stage.js`:
```js
    _mousedown: function(evt) {
       // ...
        if (shape && shape.isListening()) {
          this.clickStartShape = shape;
          shape._fireAndBubble(MOUSEDOWN, { evt: evt });
        }
        // ...
    },
    _mouseup: function(evt) {
      // workaround for mobile IE to force touch event when unhandled pointer event elevates into a mouse event
      if (Konva.UA.ieMobile) {
        return this._touchend(evt);
      }
      if (!Konva.UA.mobile) {
        this._setPointerPosition(evt);
        var shape = this.getIntersection(this.getPointerPosition()),
          clickStartShape = this.clickStartShape,
          fireDblClick = false,
          dd = Konva.DD;

        if (Konva.inDblClickWindow) {
          fireDblClick = true;
          Konva.inDblClickWindow = false;
        } else if (!dd || !dd.justDragged) {
          // don't set inDblClickWindow after dragging
          Konva.inDblClickWindow = true;
        } else if (dd) {
          dd.justDragged = false;
        }

        setTimeout(function() {
          Konva.inDblClickWindow = false;
        }, Konva.dblClickWindow);

        if (shape && shape.isListening()) {
          shape._fireAndBubble(MOUSEUP, { evt: evt });

          // detect if click or double click occurred
          if (
            Konva.listenClickTap &&
            clickStartShape &&
            clickStartShape._id === shape._id
          ) {
            shape._fireAndBubble(CLICK, { evt: evt });

            if (fireDblClick) {// <--- should check the double click target is the last mouseup target or not
              shape._fireAndBubble(DBL_CLICK, { evt: evt });
            }
          }
        }
        // ...
      }
    },
```