### PR TITLE
Add check if event is cancelable before fire preventDefault

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -494,7 +494,7 @@
 
       // always call preventDefault for desktop events because some browsers
       // try to drag and drop the canvas element
-      if (evt.preventDefault) {
+      if (evt.preventDefault && evt.cancelable) {
         evt.preventDefault();
       }
     },
@@ -526,7 +526,7 @@
 
       // always call preventDefault for desktop events because some browsers
       // try to drag and drop the canvas element
-      if (evt.preventDefault) {
+      if (evt.preventDefault && evt.cancelable) {
         evt.preventDefault();
       }
     },
@@ -602,7 +602,7 @@
 
       // always call preventDefault for desktop events because some browsers
       // try to drag and drop the canvas element
-      if (evt.preventDefault) {
+      if (evt.preventDefault && evt.cancelable) {
         evt.preventDefault();
       }
     },
@@ -623,6 +623,7 @@
         if (
           shape.isListening() &&
           shape.preventDefault() &&
+          evt.cancelable &&
           evt.preventDefault
         ) {
           evt.preventDefault();
@@ -672,6 +673,7 @@
         if (
           shape.isListening() &&
           shape.preventDefault() &&
+          evt.cancelable &&
           evt.preventDefault
         ) {
           evt.preventDefault();
@@ -710,6 +712,7 @@
           if (
             shape.isListening() &&
             shape.preventDefault() &&
+            evt.cancelable &&
             evt.preventDefault
           ) {
             evt.preventDefault();
@@ -718,7 +721,7 @@
         this._fire(CONTENT_TOUCHMOVE, { evt: evt });
       }
       if (dd) {
-        if (Konva.isDragging() && Konva.DD.node.preventDefault()) {
+        if (Konva.isDragging() && Konva.DD.node.preventDefault() && evt.cancelable) {
           evt.preventDefault();
         }
       }


### PR DESCRIPTION
Whenever evt.preventDefault() is called, but the event (evt) is not cancelable, it will throw a warning.

![image](https://user-images.githubusercontent.com/14164004/36667498-577fff0e-1aee-11e8-805e-33905e135d3b.png)

