### PR TITLE
fix doc argname & types for globalCompositeOperation

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -2092,8 +2092,8 @@
    * @name globalCompositeOperation
    * @method
    * @memberof Konva.Node.prototype
-   * @param {Number} blur
-   * @returns {Number}
+   * @param {String} type
+   * @returns {String}
    * @example
    * // get shadow blur
    * var globalCompositeOperation = shape.globalCompositeOperation();


### PR DESCRIPTION
The argument name and type for globalCompositeOperation are incorrect.
The return type is also incorrect.

This PR will fix that.