### PR TITLE
DO NOT MERGE: remove dash from arrow-head

### DIFF
--- a/src/shapes/Arrow.js
+++ b/src/shapes/Arrow.js
@@ -66,7 +66,21 @@
         ctx.closePath();
         ctx.restore();
       }
+
+      this._fillArrowHead(ctx);
+    },
+
+    // removing dash from arrow-head only, but putting it back to the
+    // intial value after render
+    _fillArrowHead: function(ctx) {
+      var isDashEnabled = this.dashEnabled();
+      if (isDashEnabled) {
+        this.dashEnabled(false);
+      }
+
       ctx.fillStrokeShape(this);
+
+      this.dashEnabled(isDashEnabled);
     }
   };
 


### PR DESCRIPTION
When rendering an Arrow that has a dashed line.  Current behavior is, the arrow head is wrapped in a surrounding dashed outline.  Which provides for an unpredictive rendering.

Also addressed in: https://github.com/konvajs/konva/issues/225

The current fix below removes the dash so a user can still apply a stroke to the arrowhead if desired.  But changes the saves and reapplies the dash attribute after the arrow is rendered.
