### PR TITLE
refactor findOne method

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -343,7 +343,7 @@ declare namespace Konva {
     clipFunc(ctx: CanvasRenderingContext2D | undefined | null): void;
     destroyChildren(): void;
     find(selector?: string | ((Node) => boolean)): Collection;
-    findOne<T extends Node>(selector: string): T;
+    findOne<T extends Node>(selector: string | ((Node) => boolean)): T;
     getAllIntersections(pos: Vector2d): Shape[];
     hasChildren(): boolean;
     removeChildren(): void;

--- a/test/unit/Container-test.js
+++ b/test/unit/Container-test.js
@@ -291,7 +291,7 @@ suite('Container', function() {
   });
 
   // ======================================================
-  test('select shape by id and name with findOne', function() {
+  test('select shape with findOne', function() {
     var stage = addStage();
     var layer = new Konva.Layer({
       id: 'myLayer'
@@ -330,6 +330,10 @@ suite('Container', function() {
     assert.equal(node, undefined, 'node should be undefined');
     node = stage.findOne('#myLayer');
     assert.equal(node, layer, 'node type should be Layer');
+    node = stage.findOne(function(node) {
+      return node.getType() === 'Shape';
+    });
+    assert.equal(node, circle, 'findOne should work with functions');
   });
 
   // ======================================================


### PR DESCRIPTION
This PR will address https://github.com/konvajs/konva/issues/371

This currently adds an escape in the recursion function for `_findByFunction`.

`_findById` doesn't need logic, and i wasn't quite sure how best to handle `_findByName`.
At some point, I think we could consolidate `_findByName` using `_findByFunction` instead.

Let me know what you think.

