### PR TITLE
update npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,7 @@
   "name": "konva",
   "version": "2.0.2",
   "author": "Anton Lavrenov",
-  "files": [
-    "README.md",
-    "konva.js",
-    "konva.min.js",
-    "src",
-    "konva.d.ts"
-  ],
+  "files": ["README.md", "konva.js", "konva.min.js", "src", "konva.d.ts"],
   "main": "konva.js",
   "typings": "./konva.d.ts",
   "scripts": {
@@ -17,7 +11,8 @@
     "build": "gulp build",
     "full-build": "gulp lint test build",
     "test": "gulp test",
-    "prettier": "prettier --write \"src/**/*.js\" \"test/**/*.js\" --single-quote"
+    "prettier":
+      "prettier --write \"src/**/*.js\" \"test/**/*.js\" --single-quote"
   },
   "devDependencies": {
     "chai": "4.1.2",
@@ -35,12 +30,10 @@
     "mocha": "4.0.1",
     "prettier": "^1.9.2"
   },
-  "keywords": [
-    "canvas",
-    "animations",
-    "graphic",
-    "html5"
-  ],
+  "keywords": ["canvas", "animations", "graphic", "html5"],
+  "prettier": {
+    "singleQuote": true
+  },
   "browser": {
     "canvas": false,
     "jsdom": false


### PR DESCRIPTION
this is just to slightly improve the dev experience a bit.  

- some users would prefer not to install `gulp` globally.  so pointing the path to the local versions.  
- also adding `prettier` config lets IDE's match your cli options config when editing.

*the collapsing arrays were done by prettier and are not intentional changes.