### PR TITLE
Set img.crossOrigin to Anonymous in Konva.Image.fromURL  to prevent tainted canvas

### DIFF
--- a/src/shapes/Image.js
+++ b/src/shapes/Image.js
@@ -239,7 +239,7 @@
       });
       callback(image);
     };
-    img.crossOrigin = "Anonymous";
+    img.crossOrigin = 'Anonymous';
     img.src = url;
   };
 })();

--- a/src/shapes/Image.js
+++ b/src/shapes/Image.js
@@ -239,6 +239,7 @@
       });
       callback(image);
     };
+    img.crossOrigin = "Anonymous";
     img.src = url;
   };
 })();


### PR DESCRIPTION
See: https://github.com/konvajs/konva/issues/382

N.B. There is also: img.crossOrigin = "Use-Credentials"; (though i figure the anonymous case is the most common).
If that is a concern, perhaps this could be add as an additional optional parameter on fromURL called `crossOrigin` that defaults to "Anonymous". If it's set to null then the field won't be set at all, and if needed the client could pass in "Use-Credentials" 

Additional discussion [here](https://stackoverflow.com/a/23123261/121477) about why `img.crossOrigin` is assigned above `img.src`