### PR TITLE
Fixed type definitions for find() and findOne()

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -342,8 +342,8 @@ declare namespace Konva {
     clipFunc(): (ctx: CanvasRenderingContext2D) => void;
     clipFunc(ctx: CanvasRenderingContext2D | undefined | null): void;
     destroyChildren(): void;
-    find(selector?: string | ((Node) => boolean)): Collection;
-    findOne<T extends Node>(selector: string | ((Node) => boolean)): T;
+    find(selector?: string | ((node: Node) => boolean)): Collection;
+    findOne<T extends Node>(selector: string | ((node: Node) => boolean)): T;
     getAllIntersections(pos: Vector2d): Shape[];
     hasChildren(): boolean;
     removeChildren(): void;


### PR DESCRIPTION
With the option `noImplicitAny` enabled in `tsconfig.json`, compilation of a project using Konva would fail because the functions `find()` and `findOne()` implicitly had an `any` type. I added proper type definitions for them. Or rather properly added variable names to the function signature, as it seems the original author just forgot to name the parameters.