### PR TITLE
Make target in HandlerFunc optional

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -6,7 +6,7 @@ declare namespace Konva {
   var DD: any;
 
   type HandlerFunc = (
-    e: { target: Konva.Shape; evt: Event; currentTarget: Konva.Node }
+    e: { target?: Konva.Shape; evt: Event; currentTarget: Konva.Node }
   ) => void;
 
   type globalCompositeOperationType =


### PR DESCRIPTION
When I subscribe to **contentMouseOut** event. There is no target event.