### PR TITLE
Small improvement to _getAbsoluteTransform() when transformEnabled is not set to 'all'

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1428,16 +1428,14 @@
     },
     _getAbsoluteTransform: function(top) {
       var at = new Konva.Transform(),
-        transformsEnabled,
-        trans;
+        transformsEnabled;
 
       // start with stage and traverse downwards to self
       this._eachAncestorReverse(function(node) {
         transformsEnabled = node.transformsEnabled();
-        trans = node.getTransform();
 
         if (transformsEnabled === 'all') {
-          at.multiply(trans);
+          at.multiply(node.getTransform());
         } else if (transformsEnabled === 'position') {
           at.translate(node.x(), node.y());
         }


### PR DESCRIPTION
A small improvement, to only call `getTransform()` inside `_getAbsoluteTransform()` when the `transformEnabled` property is set to **'all'**. (_That also eliminates the need in extra variable (`trans`) to reference the returned value._)