### PR TITLE
Support offsetX and offsetY when transformsEnabled is set to 'position'

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1427,17 +1427,16 @@
       }
     },
     _getAbsoluteTransform: function(top) {
-      var at = new Konva.Transform(),
-        transformsEnabled;
+      var at = new Konva.Transform();
 
       // start with stage and traverse downwards to self
       this._eachAncestorReverse(function(node) {
-        transformsEnabled = node.transformsEnabled();
+        var transformsEnabled = node.transformsEnabled();
 
         if (transformsEnabled === 'all') {
           at.multiply(node.getTransform());
         } else if (transformsEnabled === 'position') {
-          at.translate(node.x(), node.y());
+          at.translate(node.getX() - node.getOffsetX(), node.getY() - node.getOffsetY());
         }
       }, top);
       return at;

--- a/test/unit/Node-test.js
+++ b/test/unit/Node-test.js
@@ -1695,6 +1695,64 @@ suite('Node', function() {
   });
 
   // ======================================================
+  test('results of getAbsoluteTransform limited to position and offset transformations are the same' +
+       ' when used with transformsEnabled = \'all\' and transformsEnabled = \'position\'', function() {
+    var stage = addStage();
+    var layer1 = new Konva.Layer({
+      name: 'layerName',
+      id: 'layerId',
+      x:  90,
+      y: 110,
+      offsetX: 50,
+      offsetY: 50,
+      transformsEnabled: 'all'
+    });
+    var group1 = new Konva.Group({
+      name: 'groupName',
+      id: 'groupId',
+      x: 30,
+      y: 30,
+      offsetX: -60,
+      offsetY: -80,
+      transformsEnabled: 'all'
+    });
+    var rect1 = new Konva.Rect({
+      x: -50,
+      y: -60,
+      offsetX: 50,
+      offsetY: 50,
+      width: 50,
+      height: 50,
+      fill: 'red',
+      name: 'rectName',
+      id: 'rectId1',
+      transformsEnabled: 'all'
+    });
+
+    var layer2 = layer1.clone({ transformsEnabled: 'position' });
+    var group2 = group1.clone({ transformsEnabled: 'position' });
+    var rect2  =  rect1.clone({ transformsEnabled: 'position' });
+
+    group1.add(rect1);
+    layer1.add(group1);
+    stage.add(layer1);
+
+    group2.add(rect2);
+    layer2.add(group2);
+    stage.add(layer2);
+
+    assert.equal(layer1.getTransformsEnabled(), 'all');
+    assert.equal(group1.getTransformsEnabled(), 'all');
+    assert.equal( rect1.getTransformsEnabled(), 'all');
+
+    assert.equal(layer2.getTransformsEnabled(), 'position');
+    assert.equal(group2.getTransformsEnabled(), 'position');
+    assert.equal( rect2.getTransformsEnabled(), 'position');
+
+    assert.deepEqual(rect2.getAbsoluteTransform(), rect1.getAbsoluteTransform());
+  });
+
+  // ======================================================
   test('test dragDistance', function() {
     var stage = addStage();
     var layer = new Konva.Layer();


### PR DESCRIPTION
Supporting both `x`, `y` and `offsetX`, `offsetY` under the **'position'** option
of the `transformsEnabled` node-property makes it more useful for real apps.

Also, no real benefit in making the auxiliary variable `transformEnabled`
a part of the function closure, thus moving it to the local function itself.