### PR TITLE
Removing unused value from return statement in _eachAncestorReverse()

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1052,7 +1052,7 @@
       // func with this because it will be the only node
       if (top && top._id === this._id) {
         func(this);
-        return true;
+        return;
       }
 
       family.unshift(this);


### PR DESCRIPTION
A minor cleanup. When method `_eachAncestorReverse()` does not have
the top node argument, it returns "nothing" (`undefined`). Thus, the
`true` value returned when it has the top argument – and the current
Konva code never checks or uses that returned value – seems to be
just a side effect of copy-pasting some code in the past, or alike.

Unless the function was planned to return a Boolean value for a good
reason (in which case we'd need to add a return value to its end too),
let's remove the unused value from that return.