### PR TITLE
Update konva.d.ts for getRGB

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -11,7 +11,7 @@ declare namespace Konva {
     currentTarget: Konva.Node;
     cancelBubble: boolean;
   }
-
+  
   type HandlerFunc<E = Event> = (e: KonvaEventObject<E>) => void;
 
   enum KonvaNodeEvent {
@@ -85,10 +85,16 @@ declare namespace Konva {
     | 'saturation'
     | 'color'
     | 'luminosity';
+                   
+  export interface RGB {
+    r: number;
+    g: number;
+    b: number;
+  }
 
   export class Util {
     static getRandomColor(): string;
-    static getRGB(color: string): string;
+    static getRGB(color: string): RGB;
   }
 
   type EasingFn = (


### PR DESCRIPTION
getRGB returns an object with RGB values, not a string. 
I've set up a type RGB for typescript. 

Feel free to edit to your heart's content. (I've accidentally added whitespace through GitHub's editor on line 14. My bad)