### PR TITLE
Do not recalculate additionalWidth on every line of multiline text

### DIFF
--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -356,11 +356,11 @@ export class Text extends Shape {
 
     this.textArr = [];
     getDummyContext().font = this._getContextFont();
+    var additionalWidth = shouldAddEllipsis
+      ? this._getTextWidth(ELLIPSIS)
+      : 0;
     for (var i = 0, max = lines.length; i < max; ++i) {
       var line = lines[i];
-      var additionalWidth = shouldAddEllipsis
-        ? this._getTextWidth(ELLIPSIS)
-        : 0;
 
       var lineWidth = this._getTextWidth(line);
       if (fixedWidth && lineWidth > maxWidth) {


### PR DESCRIPTION
This is just a minor improvement (optimization) to `_setTextData()`:
Flag `shouldAddEllipsis` is not changed inside the loop, thus no need
to recalculate the value of `additionalWidth` for every line of the
original text.