### PR TITLE
Simplify the Boolean condition used in _useBufferCanvas()

### DIFF
--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -218,18 +218,12 @@ export class Shape extends Node {
   }
   _useBufferCanvas(caching) {
     return (
-      (!caching &&
-        (this.perfectDrawEnabled() &&
-          this.getAbsoluteOpacity() !== 1 &&
-          this.hasFill() &&
-          this.hasStroke() &&
-          this.getStage())) ||
-      (this.perfectDrawEnabled() &&
-        this.hasShadow() &&
-        this.getAbsoluteOpacity() !== 1 &&
-        this.hasFill() &&
-        this.hasStroke() &&
-        this.getStage())
+      (!caching || this.hasShadow()) &&
+      this.perfectDrawEnabled() &&
+      this.getAbsoluteOpacity() !== 1 &&
+      this.hasFill() &&
+      this.hasStroke() &&
+      this.getStage()
     );
   }
   /**


### PR DESCRIPTION
The original Boolean condition duplicates most of the predicates
used in both parts of the "_or_" expression. It is enough to test
them just once, which also makes it easier to figure out what
the whole criterion for using the buffer canvas is. (An extra effect
is that the code becomes smaller and potentially quicker for the
JIT compilers to handle, but I don't expect much gain here.)