### PR TITLE
Very minor optimization to _getCache()

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -143,10 +143,10 @@ export abstract class Node {
 
     // if not cached, we need to set it using the private getter method.
     if (cache === undefined) {
-      this._cache[attr] = privateGetter.call(this);
+      this._cache[attr] = cache = privateGetter.call(this);
     }
 
-    return this._cache[attr];
+    return cache;
   }
   /*
    * when the logic for a cached result depends on ancestor propagation, use this


### PR DESCRIPTION
This is just a minor change to avoid accessing the same property
in object `this._cache` twice inside `_getCache()` when its is already
set (defined). No big performance improvements probably, but given
that the cached values can be checked many times for each node
in the tree, I think it makes sense to do that small improvement.