### PR TITLE
Minor improvement to the implementation of Text._sceneFunc

### DIFF
--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -159,8 +159,7 @@ export class Text extends Shape {
     }
 
     if (padding) {
-      context.translate(padding, 0);
-      context.translate(0, alignY + padding + lineHeightPx / 2);
+      context.translate(padding, alignY + padding + lineHeightPx / 2);
     } else {
       context.translate(0, alignY + lineHeightPx / 2);
     }

--- a/test/unit/shapes/Text-test.js
+++ b/test/unit/shapes/Text-test.js
@@ -653,7 +653,7 @@ suite('Text', function() {
     stage.add(layer);
 
     var trace =
-      'clearRect(0,0,578,200);save();transform(1,0,0,1,10,10);beginPath();rect(0,0,200,100);closePath();lineWidth=2;strokeStyle=black;stroke();restore();save();transform(1,0,0,1,10,10);font=normal normal 16px Arial;textBaseline=middle;textAlign=left;translate(10,0);translate(0,50);save();translate(17.523,0);fillStyle=#555;fillText(Some awesome text,0,0);restore();restore();';
+      'clearRect(0,0,578,200);save();transform(1,0,0,1,10,10);beginPath();rect(0,0,200,100);closePath();lineWidth=2;strokeStyle=black;stroke();restore();save();transform(1,0,0,1,10,10);font=normal normal 16px Arial;textBaseline=middle;textAlign=left;translate(10,50);save();translate(17.523,0);fillStyle=#555;fillText(Some awesome text,0,0);restore();restore();';
 
     assert.equal(layer.getContext().getTrace(), trace);
   });


### PR DESCRIPTION
As the context's `translate()` is additive, there is no need for
the two consecutive calls of it inside `_sceneFunc()`: The same
effect can be achieved with with just one call of `translate()`.

A corresponding update was done in the unit test for `Text` that
had a pair of calls to `translate()` in the expected call dump.