### PR TITLE
Fix handling of the width and hight changes in the Stage class

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -112,7 +112,7 @@ export class Stage extends Container {
     this._buildDOM();
     this._bindContentEvents();
     stages.push(this);
-    this.on('widthChange heightChange', this._buildDOM);
+    this.on('widthChange heightChange', this._resizeDOM);
   }
 
   _validateAdd(child) {


### PR DESCRIPTION
Just resize the DOM elements, don't replace the current contents
with a new (empty) one.

That misbehavior kept me puzzled for quite a while this evening. :smile: