### PR TITLE
Make the calls to getGlobalKonva() working in the current code base

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,4 +50,6 @@ Konva.angleDeg = true;
  */
 Konva.showWarnings = true;
 
+Konva.glob.Konva = Konva;
+
 export default KonvaInternals;


### PR DESCRIPTION
Following the recent migration to TypeScript, `getGlobalKonva()`
returns **undefined** (as `glob.Konva` is not set) when using _konva.js_
or _konva.min.js_ inside a web application running in a browser.
This change works around the situation by explicitly setting the
`Konva` property on the `glob` object.

@lavrton, I am not sure what your plans are regarding `getGlobalKonva()`
as part of reworking the code to use TypeScript and exporting / importing
the required modules inside the code. This requested change is just to
make the current builds usable in the browsers. If you planned a deeper
rework on that part, then the change can be removed later as necessary.
If you planned to touch that part fairly soon, then feel free to skip my request.