### PR TITLE
Fix for the performance regression in the updated batchDraw()

### DIFF
--- a/src/BaseLayer.ts
+++ b/src/BaseLayer.ts
@@ -249,13 +249,13 @@ export abstract class BaseLayer extends Container {
    * @return {Konva.Layer} this
    */
   batchDraw() {
-    if (this._waitingForDraw) {
-      return;
+    if (!this._waitingForDraw) {
+      this._waitingForDraw = true;
+      Util.requestAnimFrame(() => {
+        this.draw();
+        this._waitingForDraw = false;
+      });
     }
-    Util.requestAnimFrame(() => {
-      this._waitingForDraw = false;
-      this.draw();
-    });
     return this;
   }
 

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -542,20 +542,16 @@ export const Util = {
       return -1;
     }
   },
-  _waiting: false,
   animQueue: [],
   requestAnimFrame(callback) {
     Util.animQueue.push(callback);
-    if (Util._waiting) {
-      return;
-    }
-    requestAnimationFrame(() => {
-      Util.animQueue.forEach(cb => {
-        cb();
+    if (Util.animQueue.length === 1) {
+      requestAnimationFrame(function () {
+        const queue = Util.animQueue;
+        Util.animQueue = [];
+        queue.forEach(function (cb) { cb(); });
       });
-      Util.animQueue = [];
-      Util._waiting = false;
-    });
+    }
   },
   createCanvasElement() {
     var canvas = isBrowser


### PR DESCRIPTION
The code was checking the "waiting" flags, but they were not set.
This patch corrects that part and makes a few other tweaks to the
updated logic on top of `requestAnimationFrame()`.

Fixes #562.