### PR TITLE
When removing a child, set key "parent" to null, don't delete it

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -66,7 +66,7 @@ export abstract class Container extends Node {
     for (var i = 0; i < children.length; i++) {
       child = children[i];
       // reset parent to prevent many _setChildrenIndices calls
-      delete child.parent;
+      child.parent = null;
       child.index = 0;
       child.remove();
     }
@@ -85,7 +85,7 @@ export abstract class Container extends Node {
     for (var i = 0; i < children.length; i++) {
       child = children[i];
       // reset parent to prevent many _setChildrenIndices calls
-      delete child.parent;
+      child.parent = null;
       child.index = 0;
       child.destroy();
     }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -719,7 +719,7 @@ export abstract class Node {
     if (parent && parent.children) {
       parent.children.splice(this.index, 1);
       parent._setChildrenIndices();
-      delete this.parent;
+      this.parent = null;
     }
 
     // every cached attr that is calculated via node tree


### PR DESCRIPTION
Structural changes to objects are relatively more expensive and
harder to optimize for modern JavaScript compilers, compared to
just changing object's key values. The **`parent`** property of nodes
is already set to `null` now, as part constructing node objects.
Setting it back to `null` on removal / destroy of node objects is
more consistent and a tiny little bit more efficient.

_P.S. Going forward, time permitting, I may touch a few other places
in Konva that rely on `delete` without much need in using it._