### PR TITLE
Set DD.node to null, items of Node#_cache to undefined, instead of deleting

### DIFF
--- a/src/DragAndDrop.ts
+++ b/src/DragAndDrop.ts
@@ -93,7 +93,7 @@ export const DD = {
         }
       }
 
-      delete DD.node;
+      DD.node = null;
 
       if (layer || node instanceof getGlobalKonva().Stage) {
         (layer || node).draw();

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -160,7 +160,7 @@ export abstract class Node {
   /** @lends Konva.Node.prototype */
   _clearCache(attr) {
     if (attr) {
-      delete this._cache[attr];
+      this._cache[attr] = undefined;
     } else {
       this._cache = {};
     }


### PR DESCRIPTION
In the footsteps of my previous commit. This one replaces the deletion
of `DD.node` with setting it to `null`.

In addition, the internal "implementation contract" of `Node`'s cache in
Konva is that a value is _not_ in the cache if the corresponding key lookup
in the cache returns `undefined`. Thus, the suggested approach of avoiding
the `delete` operator works well here too.