### PR TITLE
Setting DD.node to null instead of deleting

### DIFF
--- a/src/DragAndDrop.ts
+++ b/src/DragAndDrop.ts
@@ -93,7 +93,7 @@ export const DD = {
         }
       }
 
-      delete DD.node;
+      DD.node = null;
 
       if (layer || node instanceof getGlobalKonva().Stage) {
         (layer || node).draw();


### PR DESCRIPTION
In the footsteps of my previous commit. This one replaces the deletion of `DD.node` with setting it to `null`.

@lavrton, regarding that piece, I guess, we're on the same page.