### PR TITLE
Removing now-unused method Stage#_onContent

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -785,17 +785,6 @@ export class Stage extends Container {
 
     this._resizeDOM();
   }
-  _onContent(typesStr, handler) {
-    var types = typesStr.split(SPACE),
-      len = types.length,
-      n,
-      baseEvent;
-
-    for (n = 0; n < len; n++) {
-      baseEvent = types[n];
-      this.content.addEventListener(baseEvent, handler, false);
-    }
-  }
   // currently cache function is now working for stage, because stage has no its own canvas element
   cache() {
     Util.warn(


### PR DESCRIPTION
...Unless there are some specific plans to return to using it, in the future. It has been fully replaced by `Stage#_bindContentEvents` as far as I can see.