### PR TITLE
Move getDummyContext into Shape class

### DIFF
--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -74,13 +74,6 @@ var linearGradient = 'linearGradient';
 var radialGradient = 'radialGradient';
 
 var dummyContext;
-function getDummyContext() {
-  if (dummyContext) {
-    return dummyContext;
-  }
-  dummyContext = Util.createCanvasElement().getContext('2d');
-  return dummyContext;
-}
 
 export const shapes = {};
 
@@ -201,6 +194,14 @@ export class Shape<Config extends ShapeConfig = ShapeConfig> extends Node<
     );
   }
 
+  _getDummyContext() {
+    if (dummyContext) {
+      return dummyContext;
+    }
+    dummyContext = Util.createCanvasElement().getContext('2d');
+    return dummyContext;
+  }
+
   /**
    * get canvas context tied to the layer
    * @method
@@ -253,7 +254,7 @@ export class Shape<Config extends ShapeConfig = ShapeConfig> extends Node<
   }
   __getFillPattern() {
     if (this.fillPatternImage()) {
-      var ctx = getDummyContext();
+      var ctx = this._getDummyContext();
       return ctx.createPattern(
         this.fillPatternImage(),
         this.fillPatternRepeat() || 'repeat'
@@ -266,7 +267,7 @@ export class Shape<Config extends ShapeConfig = ShapeConfig> extends Node<
   __getLinearGradient() {
     var colorStops = this.fillLinearGradientColorStops();
     if (colorStops) {
-      var ctx = getDummyContext();
+      var ctx = this._getDummyContext();
 
       var start = this.fillLinearGradientStartPoint();
       var end = this.fillLinearGradientEndPoint();
@@ -286,7 +287,7 @@ export class Shape<Config extends ShapeConfig = ShapeConfig> extends Node<
   __getRadialGradient() {
     var colorStops = this.fillRadialGradientColorStops();
     if (colorStops) {
-      var ctx = getDummyContext();
+      var ctx = this._getDummyContext();
 
       var start = this.fillRadialGradientStartPoint();
       var end = this.fillRadialGradientEndPoint();

--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -64,14 +64,6 @@ var AUTO = 'auto',
   ],
   // cached variables
   attrChangeListLen = ATTR_CHANGE_LIST.length;
-var dummyContext;
-function getDummyContext() {
-  if (dummyContext) {
-    return dummyContext;
-  }
-  dummyContext = Util.createCanvasElement().getContext(CONTEXT_2D);
-  return dummyContext;
-}
 
 function _fillFunc(context) {
   context.fillText(this._partialText, this._partialTextX, this._partialTextY);
@@ -329,7 +321,7 @@ export class Text extends Shape<TextConfig> {
    * @returns {Object} { width , height} of measured text
    */
   measureSize(text) {
-    var _context = getDummyContext(),
+    var _context = this._getDummyContext(),
       fontSize = this.fontSize(),
       metrics;
 
@@ -378,7 +370,7 @@ export class Text extends Shape<TextConfig> {
     var letterSpacing = this.letterSpacing();
     var length = text.length;
     return (
-      getDummyContext().measureText(text).width +
+      this._getDummyContext().measureText(text).width +
       (length ? letterSpacing * (length - 1) : 0)
     );
   }
@@ -402,7 +394,7 @@ export class Text extends Shape<TextConfig> {
       shouldAddEllipsis = this.ellipsis() && !shouldWrap;
 
     this.textArr = [];
-    getDummyContext().font = this._getContextFont();
+    this._getDummyContext().font = this._getContextFont();
     var additionalWidth = shouldAddEllipsis ? this._getTextWidth(ELLIPSIS) : 0;
     for (var i = 0, max = lines.length; i < max; ++i) {
       var line = lines[i];


### PR DESCRIPTION
I've been adding a new custom shape based on `Konva.Text` to support basic Markdown. All went well, and was surprisingly easy thanks to Konva's general amazingness, but I had to copy more functions from `Text` into my subclass than I wanted because the `getDummyContext` function was local to `src/shapes/Text.ts`. Because I couldn't access this dummy context from my new shape, I had to bring in every function from `Text` which called `getDummyContext()` so that it referenced the same context as the other functions in my subclass.

Very possible I've missed something here (so apologies in advance) but this PR moves the `getDummyContext` function into the `Konva.Shape` class, meaning it's now much easier to subclass `Konva.Text`, e.g. to provide a custom `sceneFunc`. 

I also removed the function from `Konva.Text` as it's now available through its parent, `Konva.Shape`. 