### PR TITLE
Do not stop dragging

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -825,9 +825,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
    * node.remove();
    */
   remove() {
-    // we can have drag element but that is not dragged yet
-    // so just clear it
-    DD._dragElements.delete(this._id);
     this._remove();
     return this;
   }

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -825,9 +825,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
    * node.remove();
    */
   remove() {
-    if (this.isDragging()) {
-      this.stopDrag();
-    }
     // we can have drag element but that is not dragged yet
     // so just clear it
     DD._dragElements.delete(this._id);


### PR DESCRIPTION
Hi, 
I have prepared an [example](https://codesandbox.io/s/konva-drag-example-lfq3r) where you can reproduce my issue. Try to drag down a first rectangle and check your console.

In your console you may see something like this:

![DevTools_-_codesandbox_io_s_tender-lehmann-lfq3r](https://user-images.githubusercontent.com/18481498/62610389-e8020e00-b903-11e9-9470-7d7b8e795f0b.jpg)

Important part of a call stack I have emphasised by yellow color.
After call "insertBefore" it calls "Node.remove" where dragging will be braked...
