### PR TITLE
Fix typings in signatures of findAncestor and findAncestors

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1497,7 +1497,7 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
    * // get one of the parent group
    * var parentGroups = node.findAncestors('Group');
    */
-  findAncestors(selector, includeSelf, stopNode) {
+  findAncestors(selector?, includeSelf?, stopNode?) {
     var res: Array<Node> = [];
 
     if (includeSelf && this._isMatch(selector)) {
@@ -1530,7 +1530,7 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
    * // get one of the parent group
    * var group = node.findAncestors('.mygroup');
    */
-  findAncestor(selector, includeSelf, stopNode) {
+  findAncestor(selector?, includeSelf?, stopNode?) {
     return this.findAncestors(selector, includeSelf, stopNode)[0];
   }
   // is current node match passed selector?


### PR DESCRIPTION
In TypeScript, optional arguments must be declared as such.