### PR TITLE
Fixed zero bounds children resulting in NaN group bounds.

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -507,8 +507,7 @@ export abstract class Container<ChildType extends Node> extends Node<
         break;
       }
     }
-
-    if (hasVisible) {
+    if (hasVisible && minX !== undefined) {
       selfRect = {
         x: minX,
         y: minY,

--- a/test/unit/Container-test.js
+++ b/test/unit/Container-test.js
@@ -2207,7 +2207,21 @@ suite('Container', function() {
       'layer has exactly three children'
     );
   });
-
+  test('getClientRect - adding a zero bounds shape should result in zero bounds', function() {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+    stage.add(layer);
+    var grp = new Konva.Group();
+    var zeroRect = new Konva.Rect({x: 0, y: 0, width: 0, height: 0});
+    grp.add(zeroRect);
+    var bounds = grp.getClientRect();
+    assert.deepEqual(bounds, {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0
+    });
+  });
   test('getClientRect - test empty case', function() {
     var stage = addStage();
     var layer = new Konva.Layer();


### PR DESCRIPTION
BugFix: Invalid Client Rect returned

When containers have shapes where width or height are zero they are skipped during bounds calculation. However when a container have only such children the returned bounds will be invalid as minX, minY, maxX and maxY are still undefined.

See Unit test for simple example.
