### PR TITLE
 Fixes ShapeParams.txt typos

### DIFF
--- a/resources/doc-includes/ShapeParams.txt
+++ b/resources/doc-includes/ShapeParams.txt
@@ -33,12 +33,12 @@
      * @param {Number} [config.hitStrokeWidth] size of the stroke on hit canvas.  The default is "auto" - equals to strokeWidth
      * @param {Boolean} [config.strokeHitEnabled] flag which enables or disables stroke hit region.  The default is true
      * @param {Boolean} [config.perfectDrawEnabled] flag which enables or disables using buffer canvas.  The default is true
-     * @param {Boolean} [config.shadowForStrokeEnabled] flag which enables or disables shasow for stroke.  The default is true
+     * @param {Boolean} [config.shadowForStrokeEnabled] flag which enables or disables shadow for stroke.  The default is true
      * @param {Boolean} [config.strokeScaleEnabled] flag which enables or disables stroke scale.  The default is true
      * @param {Boolean} [config.strokeEnabled] flag which enables or disables the stroke.  The default value is true
      * @param {String} [config.lineJoin] can be miter, round, or bevel.  The default
      *  is miter
-     * @param {String} [config.lineCap] can be butt, round, or sqare.  The default
+     * @param {String} [config.lineCap] can be butt, round, or square.  The default
      *  is butt
      * @param {String} [config.shadowColor]
      * @param {Number} [config.shadowBlur]


### PR DESCRIPTION
Just two small typo fixes. Thanks for maintaining the project!