### PR TITLE
add `ignoreStroke` to transformer config

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -33,6 +33,7 @@ export interface TransformerConfig extends ContainerConfig {
   centeredScaling?: boolean;
   enabledAnchors?: Array<string>;
   node?: Rect;
+  ignoreStroke?: boolean;
   boundBoxFunc?: (oldBox: Box, newBox: Box) => Box;
 }
 


### PR DESCRIPTION
`ignoreStroke` was added in issue https://github.com/konvajs/konva/issues/486  as an option to `Konva.Transform`.

In this PR the `ignoreStroke` option is added in the `TransformerConfig` interface.

