### PR TITLE
Add missing text props to config type definition

### DIFF
--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -25,6 +25,8 @@ export interface TextConfig extends ShapeConfig {
   fontFamily?: string;
   fontSize?: number;
   fontStyle?: string;
+  fontVariant?: string;
+  textDecoration?: string;
   align?: string;
   verticalAlign?: string;
   padding?: number;


### PR DESCRIPTION
The `fontVariant` and `textDecoration` properties were missing from the `TextConfig` interface definition despite being available in the element itself. This PR adds those two properties to the config definition so, among other things, they're available for autocomplete in the `react-konva` Typescript bindings.