### PR TITLE
Make sure to schedule draw when calling removeChildren/destroyChildren

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -83,6 +83,8 @@ export abstract class Container<
       child.remove();
     });
     this.children = [];
+    // because all children were detached from parent, request draw via container
+    this._requestDraw();
     return this;
   }
   /**
@@ -98,6 +100,8 @@ export abstract class Container<
       child.destroy();
     });
     this.children = [];
+    // because all children were detached from parent, request draw via container
+    this._requestDraw();
     return this;
   }
   abstract _validateAdd(node: Node): void;

--- a/test/unit/AutoDraw-test.ts
+++ b/test/unit/AutoDraw-test.ts
@@ -71,6 +71,32 @@ describe('AutoDraw', function () {
   });
 
   // ======================================================
+  it('schedules draw when calling removeChildren/destroyChildren', () => {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+    var group1 = new Konva.Group();
+    var group2 = new Konva.Group();
+
+    stage.add(layer);
+    layer.add(group1);
+    group1.add(new Konva.Circle());
+    layer.add(group2);
+    group2.add(new Konva.Circle());
+
+    let callCount = 0;
+    layer.batchDraw = function () {
+      callCount += 1;
+      Konva.Layer.prototype.batchDraw.call(this);
+      return layer;
+    };
+
+    group1.destroyChildren();
+    assert.equal(callCount, 1);
+    group2.removeChildren();
+    assert.equal(callCount, 2);
+  });
+
+  // ======================================================
   it('schedule draw on cache', function () {
     var stage = addStage();
     var layer = new Konva.Layer();


### PR DESCRIPTION
When autoDraw is enabled, calling `removeChildren` or `destroyChildren` doesn't schedule a draw (because the children are detached before they are removed). This fix adds a schedule of a draw to those calls.