### PR TITLE
fix: avoid moveToTop if node is on top

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1324,11 +1324,15 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
       Util.warn('Node has no parent. moveToTop function is ignored.');
       return false;
     }
-    var index = this.index;
-    this.parent.children.splice(index, 1);
-    this.parent.children.push(this);
-    this.parent._setChildrenIndices();
-    return true;
+    var index = this.index,
+      len = this.parent.getChildren().length;
+    if (index < len - 1) {
+      this.parent.children.splice(index, 1);
+      this.parent.children.push(this);
+      this.parent._setChildrenIndices();
+      return true;
+    }
+    return false;
   }
   /**
    * move node up


### PR DESCRIPTION
Hi, thanks for this cool project!

Currently the [`moveToTop`](https://github.com/konvajs/konva/blob/cbe2e2f2ef67eac512abab439e9ad3acfae8c73e/src/Node.ts#L1322) method looks like this:

```ts
moveToTop() {
  if (!this.parent) {
    Util.warn('Node has no parent. moveToTop function is ignored.');
    return false;
  }
  var index = this.index;
  this.parent.children.splice(index, 1);
  this.parent.children.push(this);
  this.parent._setChildrenIndices();
  return true;
}
```

But I think this method requires a Conditional Statement like other Arrange methods in order not to execute `moveToTop` if the Node is on top.

like this:

```ts
moveToTop() {
  if (!this.parent) {
    Util.warn('Node has no parent. moveToTop function is ignored.');
    return false;
  }
  var index = this.index;
  var len = this.parent.getChildren().length;
  if (index < len - 1) {
    this.parent.children.splice(index, 1);
    this.parent.children.push(this);
    this.parent._setChildrenIndices();
    return true;
  }
  return false;
}
```

You can run an example [here](https://jsbin.com/rexemepubi/1/edit?js,console,output).
