### PR TITLE
Added error handler for Image.fromURL

### DIFF
--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -122,6 +122,7 @@ export class Image extends Shape<ImageConfig> {
    * @memberof Konva.Image
    * @param {String} url image source
    * @param {Function} callback with Konva.Image instance as first argument
+   * @param {Function} onError optional error handler
    * @example
    *  Konva.Image.fromURL(imageURL, function(image){
    *    // image is Konva.Image instance
@@ -129,7 +130,7 @@ export class Image extends Shape<ImageConfig> {
    *    layer.draw();
    *  });
    */
-  static fromURL(url, callback) {
+  static fromURL(url, callback, onError = null) {
     var img = Util.createImageElement();
     img.onload = function () {
       var image = new Image({
@@ -137,6 +138,7 @@ export class Image extends Shape<ImageConfig> {
       });
       callback(image);
     };
+    img.onerror = onError;
     img.crossOrigin = 'Anonymous';
     img.src = url;
   }

--- a/test/unit/Image-test.ts
+++ b/test/unit/Image-test.ts
@@ -356,6 +356,16 @@ describe('Image', function () {
     });
   });
 
+  it('check loading failure', function (done) {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+    stage.add(layer);
+    var src = 'non-existent.jpg';
+    Konva.Image.fromURL(src, null, function (e) {
+      done();
+    });
+  });
+
   it('check zero values', function (done) {
     loadImage('darth-vader.jpg', (imageObj) => {
       var stage = addStage();


### PR DESCRIPTION
I have been using this fix for a few months. It has proved to be very convenient when handling loading errors. In Node, I get the URL of some external image from the database, use Konva to add some text and other things, then generate and download the resulting image. 
It's great to be able to easily handle loading issues when the host is down, image has been deleted, etc.
