### PR TITLE
Fix math in Node.isClientRectOnScreen() method

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -2488,8 +2488,8 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     const screenRect = {
       x: -margin.x,
       y: -margin.y,
-      width: stage.width() + margin.x,
-      height: stage.height() + margin.y,
+      width: stage.width() + 2 * margin.x,
+      height: stage.height() + 2 * margin.y,
     };
     return Util.haveIntersection(screenRect, this.getClientRect());
   }


### PR DESCRIPTION
Hi again!
Just stumbled upon a math error in the `isClientRectOnScreen()` method. The `margin` should be multiplied by 2 before it's added to the `screenRect.width` and `screenRect.height`