### PR TITLE
Fix `Cannot read properties of undefined (reading 'getWidth')`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "mocha": "9.2.2",
     "mocha-headless-chrome": "^4.0.0",
     "parcel": "2.3.2",
+    "postcss": "^8.4.12",
     "process": "^0.11.10",
     "rollup": "^2.70.0",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -261,7 +261,7 @@ export class Context {
    * @param {Number} [bounds.height]
    */
   clear(bounds?) {
-    var canvas = this.getCanvas();
+    const canvas = this.getCanvas();
 
     if (bounds) {
       this.clearRect(
@@ -271,12 +271,14 @@ export class Context {
         bounds.height || 0
       );
     } else {
-      this.clearRect(
-        0,
-        0,
-        canvas.getWidth() / canvas.pixelRatio,
-        canvas.getHeight() / canvas.pixelRatio
-      );
+      if(canvas){
+        this.clearRect(
+            0,
+            0,
+            canvas.getWidth() / canvas.pixelRatio,
+            canvas.getHeight() / canvas.pixelRatio
+        );
+      }
     }
   }
   _applyLineCap(shape) {


### PR DESCRIPTION
postcss is required to run tests.
canvas in Context.ts is undefined on heavy redraws with react-konva & react-redux.
barely same issue https://github.com/konvajs/react-konva/issues/636