### PR TITLE
Fix math in Transform.setAbsolutePosition

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -207,25 +207,6 @@ export class Transform {
     return this.m;
   }
   /**
-   * set to absolute position via translation
-   * @method
-   * @name Konva.Transform#setAbsolutePosition
-   * @returns {Konva.Transform}
-   * @author ericdrowell
-   */
-  setAbsolutePosition(x: number, y: number) {
-    var m0 = this.m[0],
-      m1 = this.m[1],
-      m2 = this.m[2],
-      m3 = this.m[3],
-      m4 = this.m[4],
-      m5 = this.m[5],
-      yt = (m0 * (y - m5) - m1 * (x - m4)) / (m0 * m3 - m1 * m2),
-      xt = (x - m4 - m2 * yt) / m0;
-
-    return this.translate(xt, yt);
-  }
-  /**
    * convert transformation matrix back into node's attributes
    * @method
    * @name Konva.Transform#decompose


### PR DESCRIPTION
The current implementation produces incorrect results when the current rotation of the Transform is either 90° or 270°

Incorrect Results from the current implementation:
```js
const transform1 = new Konva.Transform().setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
const transform2 = new Konva.Transform().rotate(Math.PI / 4).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
const transform3 = new Konva.Transform().rotate(Math.PI / 2).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 58.020217441862236 }
const transform4 = new Konva.Transform().rotate(Math.PI / 2 * 3).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 38.68014496124148 }
const transform5 = new Konva.Transform().rotate(Math.PI).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
```

New Results:
```js
const transform1 = new Konva.Transform().setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
const transform2 = new Konva.Transform().rotate(Math.PI / 4).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
const transform3 = new Konva.Transform().rotate(Math.PI / 2).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
const transform4 = new Konva.Transform().rotate(Math.PI / 2 * 3).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
const transform5 = new Konva.Transform().rotate(Math.PI).setAbsolutePosition(25, 40);
// .getTranslation() => { x: 25, y: 40 }
```
