### PR TITLE
Declare config type for Group node

### DIFF
--- a/src/Group.ts
+++ b/src/Group.ts
@@ -1,8 +1,10 @@
 import { Util } from './Util';
-import { Container } from './Container';
+import { Container, ContainerConfig } from './Container';
 import { _registerNode } from './Global';
 import { Node } from './Node';
 import { Shape } from './Shape';
+
+export interface GroupConfig extends ContainerConfig {}
 
 /**
  * Group constructor.  Groups are used to contain shapes or other groups.

--- a/src/index-types.d.ts
+++ b/src/index-types.d.ts
@@ -83,6 +83,7 @@ declare namespace Konva {
 
   export const Group: typeof import('./Group').Group;
   export type Group = import('./Group').Group;
+  export type GroupConfig = import('./Group').GroupConfig;
 
   export const DD: typeof import('./DragAndDrop').DD;
 


### PR DESCRIPTION
The purpose for this is a pull request for react-konva to update the exposed node config, so the properties for `<Group>` are correctly typed in typescript.

Usage of an empty interface is done in the same way as in `shapes/Label.ts`.
