### PR TITLE
make sure `preventDefault()` is not called on touchend-events per default

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -737,7 +737,7 @@ export class Stage extends Container<Layer> {
 
     // always call preventDefault for desktop events because some browsers
     // try to drag and drop the canvas element
-    if (evt.cancelable) {
+    if (evt.cancelable && eventType !== "touch") {
       evt.preventDefault();
     }
   }


### PR DESCRIPTION
Even though the comment states something different the current implementation of the `pointerup` event listener always calls `preventDefault()`.

This has a very negative side effect:    
On Touch-Devices the Browser still emits `click` event, but if `peventDefault()` is called on the `touchend` event the Browser does not emit a `click` event for it.    
Therefore click-listeners registered on a parent dom-element do work on Desktop, but do nothing on Mobile/Tablet.