### PR TITLE
Allow line points to be of type TypedArray.

### DIFF
--- a/src/Validators.ts
+++ b/src/Validators.ts
@@ -142,6 +142,9 @@ export function getFunctionValidator() {
 export function getNumberArrayValidator() {
   if (Konva.isUnminified) {
     return function (val: any, attr: string) {
+      if (val instanceof Uint8Array || val instanceof Uint16Array || val instanceof  Uint32Array || val instanceof  Uint8ClampedArray) {
+        return val
+      }
       if (!Util._isArray(val)) {
         Util.warn(
           _formatValue(val) +

--- a/src/Validators.ts
+++ b/src/Validators.ts
@@ -142,7 +142,10 @@ export function getFunctionValidator() {
 export function getNumberArrayValidator() {
   if (Konva.isUnminified) {
     return function (val: any, attr: string) {
-      if (val instanceof Uint8Array || val instanceof Uint16Array || val instanceof  Uint32Array || val instanceof  Uint8ClampedArray) {
+      // Retrieve TypedArray constructor as found in MDN (if TypedArray is available)
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#description
+      const TypedArray = Int8Array ? Object.getPrototypeOf(Int8Array) : null;
+      if (TypedArray && val instanceof TypedArray) {
         return val
       }
       if (!Util._isArray(val)) {

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -51,7 +51,7 @@ function expandPoints(p, tension) {
 }
 
 export interface LineConfig extends ShapeConfig {
-  points?: number[];
+  points?: number[] | Uint8Array | Uint16Array |  Uint32Array | Uint8ClampedArray;
   tension?: number;
   closed?: boolean;
   bezier?: boolean;

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -51,7 +51,7 @@ function expandPoints(p, tension) {
 }
 
 export interface LineConfig extends ShapeConfig {
-  points?: number[] | Uint8Array | Uint16Array |  Uint32Array | Uint8ClampedArray;
+  points?: number[] | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
   tension?: number;
   closed?: boolean;
   bezier?: boolean;


### PR DESCRIPTION
For performance reasons, one may want to use a typed array when drawing lines.

This change allows this type of arrays to be used.