### PR TITLE
fix(TextPath): comparison is always false `pathCmd === {}`

### DIFF
--- a/src/shapes/TextPath.ts
+++ b/src/shapes/TextPath.ts
@@ -306,7 +306,7 @@ export class TextPath extends Shape<TextPathConfig> {
           }
         }
 
-        if (pathCmd === {} || p0 === undefined) {
+        if (Object.keys(pathCmd).length === 0 || p0 === undefined) {
           return undefined;
         }
 


### PR DESCRIPTION
## What does this PR do

This PR fixes a comparison that is always `false`: `pathCmd === {}`.

_**Example:**_

```
let a = {};

console.log(a === {} ? true : false); // print: false
```

![image](https://user-images.githubusercontent.com/13513658/183554769-d46fb90c-af39-48b9-beaa-adeca32e2061.png)
