### PR TITLE
fix: fix parsing rgba error

### DIFF
--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -324,8 +324,11 @@ export class Shape<
     return this._getCache(SHADOW_RGBA, this._getShadowRGBA);
   }
   _getShadowRGBA() {
-    if (this.hasShadow()) {
-      var rgba = Util.colorToRGBA(this.shadowColor());
+    if (!this.hasShadow()) {
+      return;
+    }
+    var rgba = Util.colorToRGBA(this.shadowColor());
+    if (rgba) {
       return (
         'rgba(' +
         rgba.r +

--- a/test/unit/Shape-test.ts
+++ b/test/unit/Shape-test.ts
@@ -1229,6 +1229,11 @@ describe('Shape', function () {
     // reset shadow
     circle.shadowColor(null);
     assert.equal(circle.getShadowRGBA(), undefined);
+
+    // illegal color
+    circle.shadowColor('#0000f');
+    assert.equal(circle.hasShadow(), true);
+    assert.equal(circle.getShadowRGBA(), undefined);
   });
 
   it('scale should also effect shadow offset', function () {


### PR DESCRIPTION
When parsing illegal color values, an error was occurs, because konva did not set a default RGBA color, so an error was occurs when accessing。

Issue：https://github.com/konvajs/konva/issues/1396