### PR TITLE
fix: fixes canvas resources release (useful for getting rid of the canvas memory leaks on Safari macOS/iOS)

### DIFF
--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -23,6 +23,7 @@ function getDevicePixelRatio() {
         1;
     return devicePixelRatio / backingStoreRatio;
   })();
+  Util.releaseCanvas(canvas);
   return _pixelRatio;
 }
 

--- a/src/Global.ts
+++ b/src/Global.ts
@@ -164,6 +164,17 @@ export const Konva = {
   isDragReady() {
     return !!Konva['DD'].node;
   },
+  /**
+   * Should Konva release canvas elements on destroy. Default is true.
+   * Useful to avoid memory leak issues in Safari on macOS/iOS.
+   * @property releaseCanvasOnDestroy
+   * @default true
+   * @name releaseCanvasOnDestroy
+   * @memberof Konva
+   * @example
+   * Konva.releaseCanvasOnDestroy = true;
+   */
+  releaseCanvasOnDestroy: true,
   // user agent
   document: glob.document,
   // insert Konva into global namespace (window)

--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -469,7 +469,7 @@ export class Layer extends Container<Group | Shape> {
   }
 
   destroy(): this {
-    Util.releaseCanvas(this.getNativeCanvasElement(), this.getCanvas()._canvas);
+    Util.releaseCanvas(this.getNativeCanvasElement(), this.getHitCanvas()._canvas);
     return super.destroy();
   }
 

--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -468,6 +468,11 @@ export class Layer extends Container<Group | Shape> {
     }
   }
 
+  destroy(): this {
+    Util.releaseCanvas(this.getNativeCanvasElement(), this.getCanvas()._canvas);
+    return super.destroy();
+  }
+
   hitGraphEnabled: GetSet<boolean, this>;
 
   clearBeforeDraw: GetSet<boolean, this>;

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -243,7 +243,12 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
    * node.clearCache();
    */
   clearCache() {
-    this._cache.delete(CANVAS);
+    if (this._cache.has(CANVAS)) {
+      const {scene, filter, hit} = this._cache.get(CANVAS);
+      Util.releaseCanvas(scene, filter, hit);
+      this._cache.delete(CANVAS);
+    }
+
     this._clearSelfAndDescendantCache();
     this._requestDraw();
     return this;

--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -278,6 +278,9 @@ export class Stage extends Container<Layer> {
     if (index > -1) {
       stages.splice(index, 1);
     }
+
+    Util.releaseCanvas(this.bufferCanvas._canvas, this.bufferHitCanvas._canvas)
+
     return this;
   }
   /**

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -958,6 +958,8 @@ export const Util = {
     }
   },
   releaseCanvas(...canvases: HTMLCanvasElement[]) {
+    if (!Konva.releaseCanvasOnDestroy) return;
+
     canvases.forEach(c => {
       c.width = 0;
       c.height = 0;

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -957,4 +957,10 @@ export const Util = {
       return evt.changedTouches[0].identifier;
     }
   },
+  releaseCanvas(...canvases: HTMLCanvasElement[]) {
+    canvases.forEach(c => {
+      c.width = 0;
+      c.height = 0;
+    })
+  }
 };

--- a/src/filters/Kaleidoscope.ts
+++ b/src/filters/Kaleidoscope.ts
@@ -197,7 +197,7 @@ export const Kaleidoscope: Filter = function (imageData) {
   var scratchData = tempCanvas
     .getContext('2d')
     .getImageData(0, 0, xSize, ySize);
-
+  Util.releaseCanvas(tempCanvas);
   // Convert thhe original to polar coordinates
   ToPolar(imageData, scratchData, {
     polarCenterX: xSize / 2,

--- a/src/shapes/TextPath.ts
+++ b/src/shapes/TextPath.ts
@@ -533,6 +533,10 @@ export class TextPath extends Shape<TextPathConfig> {
       height: maxY - minY + fontSize,
     };
   }
+  destroy(): this {
+    Util.releaseCanvas(this.dummyCanvas);
+    return super.destroy();
+  }
 
   fontFamily: GetSet<string, this>;
   fontSize: GetSet<number, this>;


### PR DESCRIPTION
Hi there!

It has been an issue for a long time in Safari, especially on iOS. This PR fixes issues with "Total canvas memory use exceeds the maximum limit (384 MB)".

Seems these are memory leaks in resources releasing for canvas elements in Safari. But Apple has been ignoring it for a while.

Releasing resources in PR made via `Utils.releaseCanvas` helper. That'll be pretty easy to remove them when Apple fixes that and it becomes unneeded.

Could you please review, merge & publish these changes.

Thank you.