### PR TITLE
fix imports in *.d.ts files for esm

### DIFF
--- a/rename-imports.mjs
+++ b/rename-imports.mjs
@@ -1,7 +1,7 @@
 import FileHound from 'filehound';
 import fs from 'fs';
 
-const files = FileHound.create().paths('./lib').ext('js').find();
+const files = FileHound.create().paths('./lib').ext(['js', 'ts']).find();
 
 files.then((filePaths) => {
   filePaths.forEach((filepath) => {
@@ -21,6 +21,9 @@ files.then((filePaths) => {
         "import * as Canvas from 'canvas.js';",
         "import * as Canvas from 'canvas';"
       );
+
+      // Handle import("./x/y/z") syntax.
+      text = text.replace(/(import\s*\(\s*['"])(.*)(?=['"])/g, '$1$2.js');
 
       fs.writeFile(filepath, text, function (err) {
         if (err) {


### PR DESCRIPTION
As proposed by @scott-lc in https://github.com/konvajs/konva/issues/1432#issuecomment-1280936366
this transforms imports also in TypeScript files, including `import()` syntax.


I tried it out locally with `npm link`.

fixes #1432
