### PR TITLE
added test in `transformer.nodes()`

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -288,7 +288,37 @@ export class Transformer extends Group {
     if (this._nodes && this._nodes.length) {
       this.detach();
     }
-    this._nodes = nodes;
+
+    const ancestors = this.getAncestors();
+
+    const filteredNodes = nodes.filter(node => {
+      // check if ancestor of the transformer
+      if (ancestors.includes(node))
+        return false;
+      
+      let pointer = node.parent;
+
+      // check if descendant of any transformer
+      while (pointer) {
+        const type = pointer.getType();
+        if (type != 'Group' && type != 'Shape')
+          break;
+        
+        if (pointer.className == Transformer.prototype.className)
+          return false;
+
+        pointer = pointer.parent;
+      }
+
+      return true;
+    });
+
+    if (filteredNodes.length != nodes.length) {
+      Util.error('nodes should not be descendants of a transformer, or ancestors of this transformer.');
+      return;
+    }
+
+    this._nodes = nodes = filteredNodes;
     if (nodes.length === 1 && this.useSingleNodeRotation()) {
       this.rotation(nodes[0].getAbsoluteRotation());
     } else {

--- a/test/unit/Transformer-test.ts
+++ b/test/unit/Transformer-test.ts
@@ -4769,4 +4769,32 @@ describe('Transformer', function () {
     assert.equal(clone.getChildren().length, tr.getChildren().length);
     assert.equal(clone.nodes().length, 0);
   });
+
+  describe('`transformer.nodes( )` should filter invalid nodes if they are descendants of a transformer or parent of the transformer', function () {
+    it('should filter children of a transformer', function () {
+      const stage = addStage()!;
+      
+      const layer = new Konva.Layer();
+      stage.add(layer);
+  
+      const tr = new Konva.Transformer();
+      layer.add(tr);
+  
+      tr.nodes([tr.children![0]]);
+      assert.equal(tr.nodes().length, 0);
+    });
+
+    it('should filter parent of the transformer', function () {
+      const stage = addStage();
+      
+      const layer = new Konva.Layer();
+      stage.add(layer);
+
+      const tr = new Konva.Transformer();
+      layer.add(tr);
+
+      tr.nodes([layer]);
+      assert.equal(tr.nodes().length, 0);
+    });
+  });
 });


### PR DESCRIPTION
Added check in `transformer.nodes(nodes)` to output error message if descendants of any transformers or ancestor of the transformer instance is in `nodes`. Raised in #1507.

Mouse move event is still fired even if `transformer._nodes` is empty though. This will cause warning messages in every mouse move event if `transformer._nodes` is empty.

fixes #1507 