### PR TITLE
extend transformer.anchorSize to support an array of width and height

### DIFF
--- a/test/unit/Transformer-test.ts
+++ b/test/unit/Transformer-test.ts
@@ -4782,4 +4782,33 @@ describe('Transformer', function () {
     tr.nodes([layer]);
     assert.equal(tr.nodes().length, 0);
   });
+
+  it('set anchor width and height to different sizes with constructor using anchorSize', function () {
+    const stage = addStage();
+
+    const layer = new Konva.Layer();
+    stage.add(layer);
+
+    const tr = new Konva.Transformer({
+      anchorSize: [10, 15],
+    });
+    layer.add(tr);
+    console.log(tr.anchorSize())
+
+    assert.deepEqual(tr.anchorSize(), [10, 15]);
+  });
+
+  it('set anchor width and height to different sizes with setter', function () {
+    const stage = addStage();
+
+    const layer = new Konva.Layer();
+    stage.add(layer);
+
+    const tr = new Konva.Transformer();
+    layer.add(tr);
+
+    tr.anchorSize([12, 14]);
+
+    assert.deepEqual(tr.anchorSize(), [12, 14]);
+  });
 });


### PR DESCRIPTION
I have come across use cases where it would be nice to have the transformer anchors width and height be set independently of one another. 

This attempts to allow that by modifying the `Transformer#anchorSize` GetterSetter to support an array of size two, specifying the anchor width and height when used. Passing a single number still sets it to a square with width height values equal to the parameter value. I don't _think_ this introduces breaking changes but if so (and this provides value) I am happy to rethink a solution.

Thanks!