### PR TITLE
 Issue when navigating from a Konva-enabled page to another page

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -1120,7 +1120,7 @@ export class Transformer extends Group {
 
   _batchChangeChild(selector: string, attrs: any) {
     const anchor = this.findOne(selector);
-    anchor.setAttrs(attrs);
+    if (anchor) anchor.setAttrs(attrs);
   }
 
   update() {


### PR DESCRIPTION
I encountered an issue when navigating from a Konva-enabled page to another page: "Cannot read properties of undefined (reading 'setAttrs')". 

After some investigation, I found that this may be caused by the absence of an anchor (such as 'top-left', 'top-center', etc.) in my Transformer, which causes an error in the code 'anchor.setAttrs(attrs)'. 

Therefore, I would like to add an if statement to check for the existence of the anchor before setting its attributes.