### PR TITLE
feat: Change Transformer transform event position

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -1102,13 +1102,13 @@ export class Transformer extends Group {
 
       const attrs = newLocalTransform.decompose();
       node.setAttrs(attrs);
-      this._fire('transform', { evt: evt, target: node });
       node._fire('transform', { evt: evt, target: node });
       node.getLayer()?.batchDraw();
     });
     this.rotation(Util._getRotation(newAttrs.rotation));
     this._resetTransformCache();
     this.update();
+    this._fire('transform', { evt: evt, target: this.getNode() });
     this.getLayer().batchDraw();
   }
   /**


### PR DESCRIPTION
If I wang to add some node to [Transformer](https://konvajs.org/api/Konva.Transformer.html) and  binding events `transformer.on('transform')` it can not set correct position, the add node will be shake, so I adjusted the position of the event `this._fire('transform')`, it work correct.