### PR TITLE
feat: Add basic support for RTL text direction.

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -68,7 +68,6 @@ var COMMA = ',',
     'strokeText',
     'transform',
     'translate',
-    'trySetLetterSpacing',
   ];
 
 var CONTEXT_PROPERTIES = [

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -68,6 +68,7 @@ var COMMA = ',',
     'strokeText',
     'transform',
     'translate',
+    'trySetLetterSpacing',
   ];
 
 var CONTEXT_PROPERTIES = [
@@ -92,6 +93,11 @@ var CONTEXT_PROPERTIES = [
 ] as const;
 
 const traceArrMax = 100;
+
+interface CanvasRenderingContext2DFeatureDetection extends CanvasRenderingContext2D {
+  letterSpacing: string | undefined;
+}
+
 /**
  * Konva wrapper around native 2d canvas context. It has almost the same API of 2d context with some additional functions.
  * With core Konva shapes you don't need to use this object. But you will use it if you want to create
@@ -705,6 +711,21 @@ export class Context {
    */
   translate(x: number, y: number) {
     this._context.translate(x, y);
+  }
+  /**
+    * Set letterSpacing if supported by browser.
+    * @method
+    * @name Konva.Context#trySetLetterSpacing
+    * @returns true if successful, false if not supported.
+    */
+  trySetLetterSpacing(letterSpacing: number): boolean {
+    var context = this._context as CanvasRenderingContext2DFeatureDetection;
+    var letterSpacingSupported = 'letterSpacing' in context;
+
+    if (letterSpacingSupported) {
+      context.letterSpacing = letterSpacing + "px";
+    }
+    return letterSpacingSupported;
   }
   _enableTrace() {
     var that = this,

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -78,6 +78,7 @@ var CONTEXT_PROPERTIES = [
   'shadowBlur',
   'shadowOffsetX',
   'shadowOffsetY',
+  'letterSpacing',
   'lineCap',
   'lineDashOffset',
   'lineJoin',
@@ -94,8 +95,8 @@ var CONTEXT_PROPERTIES = [
 
 const traceArrMax = 100;
 
-interface CanvasRenderingContext2DFeatureDetection extends CanvasRenderingContext2D {
-  letterSpacing: string | undefined;
+interface ExtendedCanvasRenderingContext2D extends CanvasRenderingContext2D {
+  letterSpacing: string;
 }
 
 /**
@@ -712,21 +713,6 @@ export class Context {
   translate(x: number, y: number) {
     this._context.translate(x, y);
   }
-  /**
-    * Set letterSpacing if supported by browser.
-    * @method
-    * @name Konva.Context#trySetLetterSpacing
-    * @returns true if successful, false if not supported.
-    */
-  trySetLetterSpacing(letterSpacing: number): boolean {
-    var context = this._context as CanvasRenderingContext2DFeatureDetection;
-    var letterSpacingSupported = 'letterSpacing' in context;
-
-    if (letterSpacingSupported) {
-      context.letterSpacing = letterSpacing + "px";
-    }
-    return letterSpacingSupported;
-  }
   _enableTrace() {
     var that = this,
       len = CONTEXT_METHODS.length,
@@ -785,7 +771,7 @@ export class Context {
 
 // supported context properties
 type CanvasContextProps = Pick<
-  CanvasRenderingContext2D,
+  ExtendedCanvasRenderingContext2D,
   (typeof CONTEXT_PROPERTIES)[number]
 >;
 

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -82,6 +82,7 @@ var CONTEXT_PROPERTIES = [
   'lineJoin',
   'lineWidth',
   'miterLimit',
+  'direction',
   'font',
   'textAlign',
   'textBaseline',

--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -57,6 +57,7 @@ var AUTO = 'auto',
   PX_SPACE = 'px ',
   SPACE = ' ',
   RIGHT = 'right',
+  RTL = 'rtl',
   WORD = 'word',
   CHAR = 'char',
   NONE = 'none',
@@ -213,6 +214,8 @@ export class Text extends Shape<TextConfig> {
 
     context.setAttr('textAlign', LEFT);
 
+    var letterSpacingSupported = context.trySetLetterSpacing(letterSpacing);
+
     // handle vertical alignment
     if (verticalAlign === MIDDLE) {
       alignY = (this.getHeight() - textArrLen * lineHeightPx - padding * 2) / 2;
@@ -288,7 +291,7 @@ export class Text extends Shape<TextConfig> {
         context.stroke();
         context.restore();
       }
-      if (letterSpacing !== 0 || align === JUSTIFY) {
+      if ((letterSpacing !== 0 && !letterSpacingSupported) || align === JUSTIFY) {
         //   var words = text.split(' ');
         spacesNumber = text.split(' ').length - 1;
         var array = stringToArray(text);

--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -207,7 +207,9 @@ export class Text extends Shape<TextConfig> {
     var lineTranslateX = 0;
     var lineTranslateY = 0;
 
-    context.setAttr('direction', direction);
+    if (direction === RTL) {
+      context.setAttr('direction', direction);
+    }
 
     context.setAttr('font', this._getContextFont());
 
@@ -315,13 +317,14 @@ export class Text extends Shape<TextConfig> {
           lineTranslateX += this.measureSize(letter).width + letterSpacing;
         }
       } else {
-        context.trySetLetterSpacing(letterSpacing);
+        if (letterSpacing !== 0) {
+          context.setAttr('letterSpacing', `${letterSpacing}px`);
+        }
         this._partialTextX = lineTranslateX;
         this._partialTextY = translateY + lineTranslateY;
         this._partialText = text;
 
         context.fillStrokeShape(this);
-        context.trySetLetterSpacing(0);
       }
       context.restore();
       if (textArrLen > 1) {

--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -42,6 +42,7 @@ export interface TextConfig extends ShapeConfig {
 var AUTO = 'auto',
   //CANVAS = 'canvas',
   CENTER = 'center',
+  INHERIT = 'inherit',
   JUSTIFY = 'justify',
   CHANGE_KONVA = 'Change.konva',
   CONTEXT_2D = '2d',
@@ -136,7 +137,7 @@ function checkDefaultFill(config?: TextConfig) {
  * @memberof Konva
  * @augments Konva.Shape
  * @param {Object} config
- * @param {String} [config.direction] default is ltr
+ * @param {String} [config.direction] default is inherit
  * @param {String} [config.fontFamily] default is Arial
  * @param {Number} [config.fontSize] in pixels.  Default is 12
  * @param {String} [config.fontStyle] can be 'normal', 'italic', or 'bold', '500' or even 'italic bold'.  'normal' is the default.
@@ -200,6 +201,8 @@ export class Text extends Shape<TextConfig> {
       shouldUnderline = textDecoration.indexOf('underline') !== -1,
       shouldLineThrough = textDecoration.indexOf('line-through') !== -1,
       n;
+    
+    direction = direction === INHERIT ? context.direction : direction;
 
     var translateY = 0;
     var translateY = lineHeightPx / 2;
@@ -714,7 +717,7 @@ Factory.overWriteSetter(Text, 'height', getNumberOrAutoValidator());
  * // set direction
  * text.direction('rtl');
  */
-Factory.addGetterSetter(Text, 'direction', 'ltr');
+Factory.addGetterSetter(Text, 'direction', INHERIT);
 
 /**
  * get/set font family

--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -22,6 +22,7 @@ export function stringToArray(string: string) {
 }
 
 export interface TextConfig extends ShapeConfig {
+  direction?: string;
   text?: string;
   fontFamily?: string;
   fontSize?: number;
@@ -46,6 +47,7 @@ var AUTO = 'auto',
   CONTEXT_2D = '2d',
   DASH = '-',
   LEFT = 'left',
+  LTR = 'ltr',
   TEXT = 'text',
   TEXT_UPPER = 'Text',
   TOP = 'top',
@@ -60,6 +62,7 @@ var AUTO = 'auto',
   NONE = 'none',
   ELLIPSIS = '…',
   ATTR_CHANGE_LIST = [
+    'direction',
     'fontFamily',
     'fontSize',
     'fontStyle',
@@ -132,6 +135,7 @@ function checkDefaultFill(config?: TextConfig) {
  * @memberof Konva
  * @augments Konva.Shape
  * @param {Object} config
+ * @param {String} [config.direction] default is ltr
  * @param {String} [config.fontFamily] default is Arial
  * @param {Number} [config.fontSize] in pixels.  Default is 12
  * @param {String} [config.fontStyle] can be 'normal', 'italic', or 'bold', '500' or even 'italic bold'.  'normal' is the default.
@@ -200,6 +204,8 @@ export class Text extends Shape<TextConfig> {
 
     var lineTranslateX = 0;
     var lineTranslateY = 0;
+
+    context.setAttr('direction', this.direction());
 
     context.setAttr('font', this._getContextFont());
 
@@ -615,6 +621,7 @@ export class Text extends Shape<TextConfig> {
     return super._useBufferCanvas();
   }
 
+  direction: GetSet<string, this>;
   fontFamily: GetSet<string, this>;
   fontSize: GetSet<number, this>;
   fontStyle: GetSet<string, this>;
@@ -681,6 +688,22 @@ Factory.overWriteSetter(Text, 'width', getNumberOrAutoValidator());
  */
 
 Factory.overWriteSetter(Text, 'height', getNumberOrAutoValidator());
+
+
+/**
+ * get/set direction
+ * @name Konva.Text#direction
+ * @method
+ * @param {String} direction
+ * @returns {String}
+ * @example
+ * // get direction
+ * var direction = text.direction();
+ *
+ * // set direction
+ * text.direction('rtl');
+ */
+Factory.addGetterSetter(Text, 'direction', 'ltr');
 
 /**
  * get/set font family

--- a/test/unit/Text-test.ts
+++ b/test/unit/Text-test.ts
@@ -1654,4 +1654,63 @@ describe('Text', function () {
 
     assert.equal(layer.getContext().getTrace(), trace);
   });
+  
+  it('sets ltr text direction', function () {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+
+    stage.add(layer);
+    var text = new Konva.Text({
+      text: 'ltr text',
+      direction: 'ltr',
+    });
+
+    layer.add(text);
+    layer.draw();
+
+    var trace =
+      'clearRect(0,0,578,200);clearRect(0,0,578,200);save();transform(1,0,0,1,0,0);font=normal normal 12px Arial;textBaseline=middle;textAlign=left;translate(0,0);save();fillStyle=black;fillText(ltr text,0,6);restore();restore();';
+
+    assert.equal(layer.getContext().getTrace(), trace);
+  });
+  
+  
+ it('sets rtl text direction', function () {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+
+    stage.add(layer);
+    var text = new Konva.Text({
+      text: 'rtl text',
+      direction: 'rtl',
+    });
+
+    layer.add(text);
+    layer.draw();
+
+    var trace =
+      'clearRect(0,0,578,200);clearRect(0,0,578,200);save();transform(1,0,0,1,0,0);direction=rtl;font=normal normal 12px Arial;textBaseline=middle;textAlign=left;translate(0,0);save();fillStyle=black;fillText(rtl text,0,6);restore();restore();';
+
+    assert.equal(layer.getContext().getTrace(), trace);
+  });
+  
+  it('sets rtl text direction with letterSpacing', function () {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+
+    stage.add(layer);
+    var text = new Konva.Text({
+      text: 'rtl text',
+      direction: 'rtl',
+      letterSpacing: 2,
+    });
+
+    layer.add(text);
+    layer.draw();
+
+    var trace =
+      'clearRect(0,0,578,200);clearRect(0,0,578,200);save();transform(1,0,0,1,0,0);direction=rtl;font=normal normal 12px Arial;textBaseline=middle;textAlign=left;translate(0,0);save();letterSpacing=2px;fillStyle=black;fillText(rtl text,0,6);restore();restore();';
+
+    assert.equal(layer.getContext().getTrace(), trace);
+  });
 });


### PR DESCRIPTION
Currently, supporting RTL languages requires workarounds as described in https://github.com/konvajs/konva/issues/1251, which has many caveats such as not being able to support `toDataUrl` or mixing LTR and RTL languages.

This PR upstreams a basic feature addition that we have to address these cases. A new property `direction` is added on the `Text` element, which is passed through to the 2d canvas during rendering.

This PR is basic to a minimum to ensure that it doesn't disrupt LTR languages, as such I'm sure there are still edge cases for RTL that it doesn't address. I wanted to keep the initial change small so that we can iterate, while this first step should still be useful for a lot of common cases that's useful to the Konva community.

Best,

xkxx