### PR TITLE
Change CDN URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Konva supports UMD loading. So you can use all possible variants to load the fra
 ### Load Konva via classical `<script>` tag from CDN:
 
 ```html
-<script src="https://unpkg.com/konva@8/konva.min.js"></script>
+<script src="https://unpkg.com/konva@9/konva.min.js"></script>
 ```
 
 ### Install with npm:


### PR DESCRIPTION
Hello.

Thank you for providing us with a great library.

The installation instructions for loading scripts from CDN had different versions in README and on the official website.

README: https://github.com/konvajs/konva#load-konva-via-classical-script-tag-from-cdn

> Load Konva via classical <script> tag from CDN:.
>`<script src="https://unpkg.com/konva@8/konva.min.js"></script>`

Official website: https://konvajs.org/docs/index.html

> Or just use script tag:.
>`<script src="https://unpkg.com/konva@9/konva.min.js"></script>`

I have modified the README to `@9`. Please merge if you are OK with it.