### PR TITLE
Update CDN URL in Quick Look

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository began as a GitHub fork of [ericdrowell/KineticJS](https://github
 # Quick Look
 
 ```html
-<script src="https://unpkg.com/konva@8/konva.min.js"></script>
+<script src="https://unpkg.com/konva@9/konva.min.js"></script>
 <div id="container"></div>
 <script>
   var stage = new Konva.Stage({


### PR DESCRIPTION
Thanks for merged #1646 

I found `@8` in Quick Look as well, and fixed this one too.
I wish I would found it in the #1646 :pray: