### PR TITLE
add data parameter to node config

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -57,6 +57,7 @@ export interface NodeConfig {
   listening?: boolean;
   id?: string;
   name?: string;
+  data?: any;
   opacity?: number;
   scale?: Vector2d;
   scaleX?: number;


### PR DESCRIPTION
An additional parameter for nodes to store individual own data.
For example: You are building a line tool where you can set bezier for each point individually. The curve handles are stored in the points array but you can't tell what point has bezier later. Sou you could use the data parameter to store this information.