### PR TITLE
export Factory Validators and GetSet

### DIFF
--- a/src/_CoreInternals.ts
+++ b/src/_CoreInternals.ts
@@ -2,6 +2,9 @@
 import { Konva as Global } from './Global';
 
 import { Util, Transform } from './Util';
+import { Factory } from './Factory';
+import * as Validators from './Validators';
+
 import { Node } from './Node';
 import { Container } from './Container';
 
@@ -24,6 +27,8 @@ import { Canvas } from './Canvas';
 
 export const Konva = Util._assign(Global, {
   Util,
+  Factory,
+  Validators,
   Transform,
   Node,
   Container,

--- a/src/index-types.d.ts
+++ b/src/index-types.d.ts
@@ -41,6 +41,7 @@ declare namespace Konva {
   export const isDragReady: () => boolean;
   export const getAngle: (angle: number) => number;
 
+  export type GetSet<Type, This> = import('./types').GetSet<Type, This>
   export type Vector2d = import('./types').Vector2d;
 
   export const Node: typeof import('./Node').Node;
@@ -63,6 +64,8 @@ declare namespace Konva {
   export type Transform = import('./Util').Transform;
 
   export const Util: typeof import('./Util').Util;
+  export const Factory: typeof import('./Factory').Factory;
+  export const Validators: typeof import('./Validators');
 
   export const Context: typeof import('./Context').Context;
   export type Context = import('./Context').Context;


### PR DESCRIPTION
Makes it easier for users to extend any element in Konva, or to create new elements.

fix: #1672

---
https://github.com/konvajs/konva/blob/master/src/index-types.d.ts

Perhaps types should be exported directly, rather than using namespace, which is currently difficult to extend.

konva.export.ts
```ts
export { Container, ContinareConfig } from "./core"
```

index.ts
```ts
import * as Konva from "./konva.export"

export default Konva
```