### PR TITLE
feat: add flag for link line visiable for Transformer's rotate

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -18,6 +18,7 @@ export interface Box extends IRect {
 export interface TransformerConfig extends ContainerConfig {
   resizeEnabled?: boolean;
   rotateEnabled?: boolean;
+  rotateLinkLineVisiable?: boolean;
   rotationSnaps?: Array<number>;
   rotationSnapTolerance?: number;
   rotateAnchorOffset?: number;
@@ -205,6 +206,7 @@ function getSnap(snaps: Array<number>, newRotationRad: number, tol: number) {
  * @param {Object} config
  * @param {Boolean} [config.resizeEnabled] Default is true
  * @param {Boolean} [config.rotateEnabled] Default is true
+ * @param {Boolean} [config.rotateLinkLineVisiable] Default is true
  * @param {Array} [config.rotationSnaps] Array of angles for rotation snaps. Default is []
  * @param {Number} [config.rotationSnapTolerance] Snapping tolerance. If closer than this it will snap. Default is 5
  * @param {Number} [config.rotateAnchorOffset] Default is 50
@@ -614,7 +616,7 @@ export class Transformer extends Group {
           shape.height() + padding * 2
         );
         ctx.moveTo(shape.width() / 2, -padding);
-        if (tr.rotateEnabled()) {
+        if (tr.rotateEnabled() && tr.rotateLinkLineVisiable()) {
           ctx.lineTo(
             shape.width() / 2,
             -tr.rotateAnchorOffset() * Util._sign(shape.height()) - padding
@@ -1289,6 +1291,7 @@ export class Transformer extends Group {
   anchorSize: GetSet<number, this>;
   resizeEnabled: GetSet<boolean, this>;
   rotateEnabled: GetSet<boolean, this>;
+  rotateLinkLineVisiable: GetSet<boolean, this>;
   rotateAnchorOffset: GetSet<number, this>;
   rotationSnapTolerance: GetSet<number, this>;
   rotateAnchorCursor: GetSet<string, this>;
@@ -1421,6 +1424,21 @@ Factory.addGetterSetter(Transformer, 'anchorSize', 10, getNumberValidator());
  * transformer.rotateEnabled(false);
  */
 Factory.addGetterSetter(Transformer, 'rotateEnabled', true);
+
+/**
+ * get/set visiable to rotate link line.
+ * @name Konva.Transformer#rotateLinkLineVisiable
+ * @method
+ * @param {Boolean} enabled
+ * @returns {Boolean}
+ * @example
+ * // get
+ * var rotateLinkLineVisiable = transformer.rotateLinkLineVisiable();
+ *
+ * // set
+ * transformer.rotateLinkLineVisiable(false);
+ */
+Factory.addGetterSetter(Transformer, 'rotateLinkLineVisiable', true);
 
 /**
  * get/set rotation snaps angles.


### PR DESCRIPTION
Hide the line of the Konva rotation handle and keep the rotation function.

Resolve the https://github.com/konvajs/konva/discussions/1688.

```js
var rect = new Konva.Rect({
  x: 100,
  y: 100,
  width: 200,
  height: 200,
  fill: "pink",
  draggable: true
});

var tr = new Konva.Transformer({
  nodes: [rect ],
  anchorSize: 10,
  rotateLinkLineVisiable: false, // add this flag to hide the link line
});
```
The `rotateLinkLineVisiable`'s default value is true, when the value is `false` will be like the follow:
![image](https://github.com/konvajs/konva/assets/41336612/12112f70-c970-4ea9-857e-896fccd6f26a)

