### PR TITLE
Add support for ctx.roundRect

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -592,12 +592,14 @@ export class Context {
    * @method
    * @name Konva.Context#roundRect
    */
-  roundRect(x: number, y: number, width: number, height: number, radii: number) {
-    if (this._context.roundRect) {
-      this._context.roundRect(x, y, width, height, radii);
-    } else {
-      this._context.rect(x, y, width, height);
-    }
+  roundRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    radii: number
+  ) {
+    this._context.roundRect(x, y, width, height, radii);
   }
   /**
    * putImageData function.

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -58,6 +58,7 @@ var COMMA = ',',
     'putImageData',
     'quadraticCurveTo',
     'rect',
+    'roundRect',
     'restore',
     'rotate',
     'save',
@@ -585,6 +586,18 @@ export class Context {
    */
   rect(x: number, y: number, width: number, height: number) {
     this._context.rect(x, y, width, height);
+  }
+  /**
+   * roundRect function.
+   * @method
+   * @name Konva.Context#roundRect
+   */
+  roundRect(x: number, y: number, width: number, height: number, radii: number) {
+    if (this._context.roundRect) {
+      this._context.roundRect(x, y, width, height, radii);
+    } else {
+      this._context.rect(x, y, width, height);
+    }
   }
   /**
    * putImageData function.

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -597,7 +597,7 @@ export class Context {
     y: number,
     width: number,
     height: number,
-    radii: number
+    radii: number | DOMPointInit | (number | DOMPointInit)[]
   ) {
     this._context.roundRect(x, y, width, height, radii);
   }

--- a/test/unit/Context-test.ts
+++ b/test/unit/Context-test.ts
@@ -22,6 +22,7 @@ describe('Context', function () {
     'arc',
     'arcTo',
     'rect',
+    'roundRect',
     'ellipse',
     'fill',
     'stroke',


### PR DESCRIPTION
According to the [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect), we should be able to use the `roundRect()` function on the canvas context.

While we can create rounded rectangles by setting `cornerRadius` to `Rect()`, the `roundRect()` function is particularly useful when we want to clip using a rounded rectangle shape with `clipFunc()`.

Since this function appears to be a recent implementation, it might be a good idea to check if it's supported before running it. 

Here I chose to run `rect()` instead so the result would be at least a rectangle but let me know if you think that we should handle this in a different manner.