### PR TITLE
Update Transformer.ts

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -615,6 +615,7 @@ export class Transformer extends Group {
       width: 0,
       height: 0,
       draggable: true,
+      listening: false,
       sceneFunc(ctx, shape) {
         var tr = shape.getParent() as Transformer;
         var padding = tr.padding();


### PR DESCRIPTION
If Transformer is moved to the top, it will block event capture，Setting the listening of the ”back“ to false can avoid this issue