### PR TITLE
Update `fill` type to accept `CanvasGradient`

### DIFF
--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -26,7 +26,7 @@ export type LineJoin = 'round' | 'bevel' | 'miter';
 export type LineCap = 'butt' | 'round' | 'square';
 
 export interface ShapeConfig extends NodeConfig {
-  fill?: string;
+  fill?: string | CanvasGradient;
   fillPatternImage?: HTMLImageElement;
   fillPatternX?: number;
   fillPatternY?: number;

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -766,7 +766,7 @@ export class Shape<
   dash: GetSet<number[], this>;
   dashEnabled: GetSet<boolean, this>;
   dashOffset: GetSet<number, this>;
-  fill: GetSet<string, this>;
+  fill: GetSet<string | CanvasGradient, this>;
   fillEnabled: GetSet<boolean, this>;
   fillLinearGradientColorStops: GetSet<Array<number | string>, this>;
   fillLinearGradientStartPoint: GetSet<Vector2d, this>;
@@ -815,7 +815,7 @@ export class Shape<
   shadowOffsetY: GetSet<number, this>;
   shadowOpacity: GetSet<number, this>;
   shadowBlur: GetSet<number, this>;
-  stroke: GetSet<string, this>;
+  stroke: GetSet<string | CanvasGradient, this>;
   strokeEnabled: GetSet<boolean, this>;
   fillAfterStrokeEnabled: GetSet<boolean, this>;
   strokeScaleEnabled: GetSet<boolean, this>;


### PR DESCRIPTION
Currently `fill` property, defined in `ShapeConfig`, only allows for strings to be passed.
But despite that it is actually possible to pass `CanvasGradient` to the `fill`, and it renders correctly ([codesandbox demo](https://codesandbox.io/p/sandbox/konva-fill-gradient-example-qnqjl8?file=%2Fsrc%2Findex.ts%3A1%2C13&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clwz87kke0006356mahewio4n%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clwz87kke0002356mnqf9l7bh%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clwz87kke0003356m3k1xn1h7%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clwz87kke0005356m94k6fxon%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clwz87kke0002356mnqf9l7bh%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clwz87kke0001356m4j0pkdl5%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.ts%2522%252C%2522state%2522%253A%2522IDLE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A1%252C%2522startColumn%2522%253A13%252C%2522endLineNumber%2522%253A1%252C%2522endColumn%2522%253A13%257D%255D%257D%255D%252C%2522id%2522%253A%2522clwz87kke0002356mnqf9l7bh%2522%252C%2522activeTabId%2522%253A%2522clwz87kke0001356m4j0pkdl5%2522%257D%252C%2522clwz87kke0005356m94k6fxon%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clwz87kke0004356mr611g0za%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clwz87kke0005356m94k6fxon%2522%252C%2522activeTabId%2522%253A%2522clwz87kke0004356mr611g0za%2522%257D%252C%2522clwz87kke0003356m3k1xn1h7%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clwz87kke0003356m3k1xn1h7%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D))

This PR adds `CanvasGradient` as one of possible values of `fill`, the same way it is done for `stroke`:
https://github.com/konvajs/konva/blob/68b4ea3cb65f7ebd838f7e420958d26b59088f0f/src/Shape.ts#L60