### PR TITLE
perf: Make index of Node readonly to prevent potential perf problem

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -83,7 +83,6 @@ export abstract class Container<
     this.getChildren().forEach((child) => {
       // reset parent to prevent many _setChildrenIndices calls
       child.parent = null;
-      child.index = 0;
       child.remove();
     });
     this.children = [];
@@ -100,7 +99,6 @@ export abstract class Container<
     this.getChildren().forEach((child) => {
       // reset parent to prevent many _setChildrenIndices calls
       child.parent = null;
-      child.index = 0;
       child.destroy();
     });
     this.children = [];
@@ -139,7 +137,6 @@ export abstract class Container<
       return this;
     }
     this._validateAdd(child);
-    child.index = this.getChildren().length;
     child.parent = this;
     child._clearCaches();
     this.getChildren().push(child);
@@ -335,12 +332,6 @@ export abstract class Container<
     this.children?.forEach(function (node) {
       node._clearSelfAndDescendantCache(attr);
     });
-  }
-  _setChildrenIndices() {
-    this.children?.forEach(function (child, n) {
-      child.index = n;
-    });
-    this._requestDraw();
   }
   drawScene(can?: SceneCanvas, top?: Node, bufferCanvas?: SceneCanvas) {
     var layer = this.getLayer()!,

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -145,7 +145,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     [index: string]: Array<{ name: string; handler: Function }>;
   } = {};
   attrs: any = {};
-  index = 0;
   _allEventListeners: null | Array<Function> = null;
   parent: Container | null = null;
   _cache: Map<string, any> = new Map<string, any>();
@@ -170,6 +169,17 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     this._shouldFireChangeEvents = true;
 
     // all change event listeners are attached to the prototype
+  }
+
+  get index() {
+    if (this.parent) {
+      return this.parent.children.indexOf(this);
+    }
+    return -1;
+  }
+
+  set index(_val: number) {
+
   }
 
   hasChildren() {
@@ -854,7 +864,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
 
     if (parent && parent.children) {
       parent.children.splice(this.index, 1);
-      parent._setChildrenIndices();
       this.parent = null;
     }
   }
@@ -1361,7 +1370,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     if (index < len - 1) {
       this.parent.children.splice(index, 1);
       this.parent.children.push(this);
-      this.parent._setChildrenIndices();
       return true;
     }
     return false;
@@ -1382,7 +1390,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     if (index < len - 1) {
       this.parent.children.splice(index, 1);
       this.parent.children.splice(index + 1, 0, this);
-      this.parent._setChildrenIndices();
       return true;
     }
     return false;
@@ -1402,7 +1409,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     if (index > 0) {
       this.parent.children.splice(index, 1);
       this.parent.children.splice(index - 1, 0, this);
-      this.parent._setChildrenIndices();
       return true;
     }
     return false;
@@ -1422,7 +1428,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     if (index > 0) {
       this.parent.children.splice(index, 1);
       this.parent.children.unshift(this);
-      this.parent._setChildrenIndices();
       return true;
     }
     return false;
@@ -1444,7 +1449,6 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     var index = this.index;
     this.parent.children.splice(index, 1);
     this.parent.children.splice(zIndex, 0, this);
-    this.parent._setChildrenIndices();
     return this;
   }
   /**

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -175,7 +175,7 @@ export abstract class Node<Config extends NodeConfig = NodeConfig> {
     if (this.parent) {
       return this.parent.children.indexOf(this);
     }
-    return -1;
+    return 0;
   }
 
   set index(_val: number) {


### PR DESCRIPTION
Make index of Node readonly to prevent potential remove child with complexity o(n^2)

Note that **Konva.Container#removeChildren** function comment with these line
> reset parent to prevent many _setChildrenIndices calls

That means without reset the parent, **Konva.Node#remove** would call **_setChildrenIndice** which will take into extra o(n^2) complexity. It works in this case but failed in other case such as call remove node in a certain loop, which offen ocurrs  in increasing draw visible node and decreasing destory invisible node in current viewport.

Thus replace the index property with readonly index is a better way to prevent the unexpected complextiy by frequent operation of a Konva Node. 