### PR TITLE
fix: specify type

### DIFF
--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -2,7 +2,7 @@ import { Factory } from '../Factory';
 import { Shape, ShapeConfig } from '../Shape';
 import { _registerNode } from '../Global';
 
-import { GetSet, PathSegment, Vector2d } from '../types';
+import { GetSet, PathSegment } from '../types';
 import {
   getCubicArcLength,
   getQuadraticArcLength,
@@ -235,10 +235,7 @@ export class Path extends Shape<PathConfig> {
     return pathLength;
   }
 
-  static getPointAtLengthOfDataArray(
-    length: number,
-    dataArray
-  ): Vector2d | null {
+  static getPointAtLengthOfDataArray(length: number, dataArray) {
     var point,
       i = 0,
       ii = dataArray.length;
@@ -322,7 +319,7 @@ export class Path extends Shape<PathConfig> {
     return null;
   }
 
-  static getPointOnLine(dist, P1x, P1y, P2x, P2y, fromX?, fromY?): Vector2d {
+  static getPointOnLine(dist, P1x, P1y, P2x, P2y, fromX?, fromY?) {
     fromX = fromX ?? P1x;
     fromY = fromY ?? P1y;
 
@@ -357,17 +354,7 @@ export class Path extends Shape<PathConfig> {
     return { x: ix + adjustedRun, y: iy + adjustedRise };
   }
 
-  static getPointOnCubicBezier(
-    pct,
-    P1x,
-    P1y,
-    P2x,
-    P2y,
-    P3x,
-    P3y,
-    P4x,
-    P4y
-  ): Vector2d {
+  static getPointOnCubicBezier(pct, P1x, P1y, P2x, P2y, P3x, P3y, P4x, P4y) {
     function CB1(t) {
       return t * t * t;
     }
@@ -388,15 +375,7 @@ export class Path extends Shape<PathConfig> {
       y: y,
     };
   }
-  static getPointOnQuadraticBezier(
-    pct,
-    P1x,
-    P1y,
-    P2x,
-    P2y,
-    P3x,
-    P3y
-  ): Vector2d {
+  static getPointOnQuadraticBezier(pct, P1x, P1y, P2x, P2y, P3x, P3y) {
     function QB1(t) {
       return t * t;
     }

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -2,7 +2,7 @@ import { Factory } from '../Factory';
 import { Shape, ShapeConfig } from '../Shape';
 import { _registerNode } from '../Global';
 
-import { GetSet, PathSegment } from '../types';
+import { GetSet, PathSegment, Vector2d } from '../types';
 import {
   getCubicArcLength,
   getQuadraticArcLength,
@@ -235,7 +235,10 @@ export class Path extends Shape<PathConfig> {
     return pathLength;
   }
 
-  static getPointAtLengthOfDataArray(length: number, dataArray) {
+  static getPointAtLengthOfDataArray(
+    length: number,
+    dataArray
+  ): Vector2d | null {
     var point,
       i = 0,
       ii = dataArray.length;
@@ -319,7 +322,7 @@ export class Path extends Shape<PathConfig> {
     return null;
   }
 
-  static getPointOnLine(dist, P1x, P1y, P2x, P2y, fromX?, fromY?) {
+  static getPointOnLine(dist, P1x, P1y, P2x, P2y, fromX?, fromY?): Vector2d {
     fromX = fromX ?? P1x;
     fromY = fromY ?? P1y;
 
@@ -354,7 +357,17 @@ export class Path extends Shape<PathConfig> {
     return { x: ix + adjustedRun, y: iy + adjustedRise };
   }
 
-  static getPointOnCubicBezier(pct, P1x, P1y, P2x, P2y, P3x, P3y, P4x, P4y) {
+  static getPointOnCubicBezier(
+    pct,
+    P1x,
+    P1y,
+    P2x,
+    P2y,
+    P3x,
+    P3y,
+    P4x,
+    P4y
+  ): Vector2d {
     function CB1(t) {
       return t * t * t;
     }
@@ -375,7 +388,15 @@ export class Path extends Shape<PathConfig> {
       y: y,
     };
   }
-  static getPointOnQuadraticBezier(pct, P1x, P1y, P2x, P2y, P3x, P3y) {
+  static getPointOnQuadraticBezier(
+    pct,
+    P1x,
+    P1y,
+    P2x,
+    P2y,
+    P3x,
+    P3y
+  ): Vector2d {
     function QB1(t) {
       return t * t;
     }

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -235,8 +235,8 @@ export class Path extends Shape<PathConfig> {
     return pathLength;
   }
 
-  static getPointAtLengthOfDataArray(length: number, dataArray) {
-    var point,
+  static getPointAtLengthOfDataArray(length: number, dataArray: PathSegment[]) {
+    var points: number[],
       i = 0,
       ii = dataArray.length;
 
@@ -250,18 +250,18 @@ export class Path extends Shape<PathConfig> {
     }
 
     if (i === ii) {
-      point = dataArray[i - 1].points.slice(-2);
+      points = dataArray[i - 1].points.slice(-2);
       return {
-        x: point[0],
-        y: point[1],
+        x: points[0],
+        y: points[1],
       };
     }
 
     if (length < 0.01) {
-      point = dataArray[i].points.slice(0, 2);
+      points = dataArray[i].points.slice(0, 2);
       return {
-        x: point[0],
-        y: point[1],
+        x: points[0],
+        y: points[1],
       };
     }
 
@@ -319,7 +319,15 @@ export class Path extends Shape<PathConfig> {
     return null;
   }
 
-  static getPointOnLine(dist, P1x, P1y, P2x, P2y, fromX?, fromY?) {
+  static getPointOnLine(
+    dist: number,
+    P1x: number,
+    P1y: number,
+    P2x: number,
+    P2y: number,
+    fromX?: number,
+    fromY?: number
+  ) {
     fromX = fromX ?? P1x;
     fromY = fromY ?? P1y;
 

--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -392,13 +392,13 @@ export class Text extends Shape<TextConfig> {
    * That method can't handle multiline text.
    * @method
    * @name Konva.Text#measureSize
-   * @param {String} [text] text to measure
-   * @returns {Object} { width , height} of measured text
+   * @param {String} text text to measure
+   * @returns {Object} { width , height } of measured text
    */
-  measureSize(text) {
+  measureSize(text: string) {
     var _context = getDummyContext(),
       fontSize = this.fontSize(),
-      metrics;
+      metrics: TextMetrics;
 
     _context.save();
     _context.font = this._getContextFont();


### PR DESCRIPTION
Hello 😄 

Is there a reason for not specifying the type for the following changes?
I changed it to use it more accurately.
Thx.

## Path
### Before
```typescript
export declare class Path extends Shape<PathConfig> {
    // ...
    static getPointAtLengthOfDataArray(length: number, dataArray: any): {
        x: any;
        y: any;
    } | null;
    static getPointOnLine(dist: any, P1x: any, P1y: any, P2x: any, P2y: any, fromX?: any, fromY?: any): {
        x: any;
        y: any;
    };
}
```

### After
```typescript
export declare class Path extends Shape<PathConfig> {
    // ...
    static getPointAtLengthOfDataArray(length: number, dataArray: any): Vector2d | null;
    static getPointOnLine(dist: any, P1x: any, P1y: any, P2x: any, P2y: any, fromX?: any, fromY?: any): Vector2d;
}
```

## Text
### Before
```typescript
export declare class Text extends Shape<TextConfig> {
    // ...
    measureSize(text: any): {
        actualBoundingBoxAscent: any;
        actualBoundingBoxDescent: any;
        actualBoundingBoxLeft: any;
        actualBoundingBoxRight: any;
        alphabeticBaseline: any;
        emHeightAscent: any;
        emHeightDescent: any;
        fontBoundingBoxAscent: any;
        fontBoundingBoxDescent: any;
        hangingBaseline: any;
        ideographicBaseline: any;
        width: any;
        height: number;
    };
}
```

### After
```typescript
export declare class Text extends Shape<TextConfig> {
    // ...
    measureSize(text: string): {
        actualBoundingBoxAscent: number;
        actualBoundingBoxDescent: number;
        actualBoundingBoxLeft: number;
        actualBoundingBoxRight: number;
        alphabeticBaseline: number;
        emHeightAscent: number;
        emHeightDescent: number;
        fontBoundingBoxAscent: number;
        fontBoundingBoxDescent: number;
        hangingBaseline: number;
        ideographicBaseline: number;
        width: number;
        height: number;
    };
}
```


