### PR TITLE
tsconfig ilb to es2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2018",
     // "sourceMap": true,
     "noEmitOnError": true,
-    "lib": ["ES2015", "dom"],
+    "lib": ["ES2019", "dom"],
     "moduleResolution": "node",
     "declaration": true,
     "removeComments": false,


### PR DESCRIPTION
to fix this errors:

```bash
src/shapes/Text.ts:565:27 - error TS2550: Property 'trimRight' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

565             match = match.trimRight();
                              ~~~~~~~~~

src/shapes/Text.ts:582:25 - error TS2550: Property 'trimLeft' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2019' or later.

582             line = line.trimLeft();
                            ~~~~~~~~
```