### PR TITLE
defensive check for error in browser

### DIFF
--- a/src/Global.ts
+++ b/src/Global.ts
@@ -154,7 +154,7 @@ export const Konva = {
    * @memberof Konva
    */
   isDragging() {
-    return Konva['DD'].isDragging;
+    return Konva['DD']?.isDragging;
   },
   isTransforming() {
     return Konva['Transformer']?.isTransforming();


### PR DESCRIPTION
I have an error when using in the browser (angular 18). It's probably because the Global object is not defined in the browser.

With this defensive check, everything works fine.