### PR TITLE
Adjust dblclick trigger conditions

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -686,7 +686,7 @@ export class Stage extends Container<Layer> {
 
       let fireDblClick = false;
       if (Konva['_' + eventType + 'InDblClickWindow']) {
-        fireDblClick = true;
+        if (evt.button === 0) fireDblClick = true;
         clearTimeout(this[eventType + 'DblTimeout']);
       } else if (!DD.justDragged) {
         // don't set inDblClickWindow after dragging


### PR DESCRIPTION
Undouble-clicking the right or middle mouse button triggers a dblclick event.