### PR TITLE
Resolve the issue of other canvases being unable to interact when overlapping on mobile devices.

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -754,7 +754,7 @@ export class Stage extends Container<Layer> {
     // TODO: are we sure we need to prevent default at all?
     // do not call this function on mobile because it prevent "click" event on all parent containers
     // but apps may listen to it.
-    if (evt.cancelable && eventType !== 'touch') {
+    if (evt.cancelable && eventType !== 'touch' && eventType !== 'pointer') {
       evt.preventDefault();
     }
   }


### PR DESCRIPTION
Hello author, I have a problem (by translations).
My project uses both Openseadragon and Konva. Openseadragon is also a Canvas library, and Konva is a child element of Openseadragon.

```Javascript
createCanvas() {
    this._canvasDiv = document.createElement('div');
    this._canvasDiv.style.position = 'absolute';
    this._canvasDiv.style.left = '0';
    this._canvasDiv.style.top = '0';
    this._canvasDiv.style.width = '100%';
    this._canvasDiv.style.height = '100%';
    this._canvasDiv.setAttribute('id', this._id);
    this._viewer?.canvas.appendChild(this._canvasDiv);
    this._konvaStage = new Konva.Stage({
      container: this._id,
      width: this._containerWidth,
      height: this._containerHeight
    }); 
  }
```
I initialized Konva in this way. _viewer is a class of Openseadragon. I added Konva to Openseadragon. Then I used Konva to mark and draw, and everything was normal, except on the mobile side.

I checked for a long time and finally found this code through the keyword mobile. Adding the judgment can meet my needs, but I don’t know if it will affect other codes.
At first glance, it seems more like you missed the judgment of pointer?

```javascript
if (evt.cancelable && eventType !== 'touch' && eventType !== 'pointer') {
    evt.preventDefault();
}
```

After adding this judgment code, the problem that Openseadragon can only be dragged once is solved. It seems that lowering the version of Openseadragon can also solve this conflict problem, but my project cannot lower the version of Openseadragon, so I proposed this PR.

