### PR TITLE
fix: Transformer doesn't change when the angle of Arc changes #1871

### DIFF
--- a/src/shapes/Arc.ts
+++ b/src/shapes/Arc.ts
@@ -98,7 +98,12 @@ export class Arc extends Shape<ArcConfig> {
 
 Arc.prototype._centroid = true;
 Arc.prototype.className = 'Arc';
-Arc.prototype._attrsAffectingSize = ['innerRadius', 'outerRadius'];
+Arc.prototype._attrsAffectingSize = [
+  'innerRadius',
+  'outerRadius',
+  'angle',
+  'clockwise',
+];
 _registerNode(Arc);
 
 // add getters setters


### PR DESCRIPTION
"angle" and "clockwise" will affect size both, so I added them to Arc.prototype._attrsAffectingSize.