### PR TITLE
bigger transformer anchors on touch devices (ipad)

### DIFF
--- a/src/shapes/Transformer.ts
+++ b/src/shapes/Transformer.ts
@@ -15,6 +15,8 @@ export interface Box extends IRect {
   rotation: number;
 }
 
+const isTouchDevice = 'ontouchstart' in window
+
 export interface TransformerConfig extends ContainerConfig {
   resizeEnabled?: boolean;
   rotateEnabled?: boolean;
@@ -1164,7 +1166,8 @@ export class Transformer extends Group {
     const resizeEnabled = this.resizeEnabled();
     const padding = this.padding();
 
-    const anchorSize = this.anchorSize();
+    const anchorSizeOrigin = this.anchorSize();
+    const anchorSize = isTouchDevice ? anchorSizeOrigin * 2 : anchorSizeOrigin;
     const anchors = this.find<Rect>('._anchor');
     anchors.forEach((node) => {
       node.setAttrs({


### PR DESCRIPTION
It would be nice to have bigger anchors on transformers for touch devices (ipad in my case)

Currently the resizing is difficult on an ipad with the default settings.

Maybe we should add a `hitFunc` on the anchors to have a bigger surface on touch device.