### PR TITLE
feat: add support for miter-limit

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -304,6 +304,12 @@ export class Context {
       this.setAttr('lineJoin', lineJoin);
     }
   }
+  _applyMiterLimit(shape: Shape) {
+    const miterLimit = shape.attrs.miterLimit;
+    if (miterLimit != null) {
+      this.setAttr('miterLimit', miterLimit);
+    }
+  }
 
   setAttr(attr: string, val) {
     this._context[attr] = val;

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -66,6 +66,7 @@ export interface ShapeConfig extends NodeConfig {
   strokeEnabled?: boolean;
   lineJoin?: LineJoin;
   lineCap?: LineCap;
+  miterLimit?: number;
   sceneFunc?: (con: Context, shape: Shape) => void;
   hitFunc?: (con: Context, shape: Shape) => void;
   shadowColor?: string;
@@ -214,14 +215,14 @@ export class Shape<
   }
 
   /**
-   * @deprecated 
+   * @deprecated
    */
   getContext() {
     Util.warn('shape.getContext() method is deprecated. Please do not use it.');
     return this.getLayer()!.getContext();
   }
   /**
-   * @deprecated 
+   * @deprecated
    */
   getCanvas() {
     Util.warn('shape.getCanvas() method is deprecated. Please do not use it.');
@@ -637,6 +638,7 @@ export class Shape<
       bufferContext.clear();
       bufferContext.save();
       bufferContext._applyLineJoin(this);
+      bufferContext._applyMiterLimit(this);
       // layer might be undefined if we are using cache before adding to layer
       const o = this.getAbsoluteTransform(top).getMatrix();
       bufferContext.transform(o[0], o[1], o[2], o[3], o[4], o[5]);
@@ -660,6 +662,7 @@ export class Shape<
       );
     } else {
       context._applyLineJoin(this);
+      context._applyMiterLimit(this);
 
       if (!cachingSelf) {
         const o = this.getAbsoluteTransform(top).getMatrix();
@@ -710,6 +713,7 @@ export class Shape<
     }
     context.save();
     context._applyLineJoin(this);
+    context._applyMiterLimit(this);
 
     const selfCache = this === top;
     if (!selfCache) {
@@ -828,6 +832,7 @@ export class Shape<
   hitFunc: GetSet<ShapeConfigHandler<this>, this>;
   lineCap: GetSet<LineCap, this>;
   lineJoin: GetSet<LineJoin, this>;
+  miterLimit: GetSet<number, this>;
   perfectDrawEnabled: GetSet<boolean, this>;
   sceneFunc: GetSet<ShapeConfigHandler<this>, this>;
   shadowColor: GetSet<string, this>;
@@ -1082,6 +1087,22 @@ Factory.addGetterSetter(Shape, 'lineCap');
  *
  * // set line cap
  * shape.lineCap('round');
+ */
+
+Factory.addGetterSetter(Shape, 'miterLimit');
+
+/**
+ * get/set miterLimit.
+ * @name Konva.Shape#miterLimit
+ * @method
+ * @param {Number} miterLimit
+ * @returns {Number}
+ * @example
+ * // get miter limit
+ * var miterLimit = shape.miterLimit();
+ *
+ * // set miter limit
+ * shape.miterLimit(10);
  */
 
 Factory.addGetterSetter(Shape, 'sceneFunc');


### PR DESCRIPTION
Adds support for [`miterLimit`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/miterLimit)

> A number specifying the miter limit ratio, in coordinate space units. Zero, negative, [Infinity](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity), and [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) values are ignored. The default value is 10.0.

The test includes a triangle, where one corner would be affected by the correct miter-limit of 3:

<img width="578" height="200" alt="image" src="https://github.com/user-attachments/assets/b8bace5d-9277-4431-b0e1-21af73d89c6e" />



Where the default miter limit (10) would not bevel any corners:

<img width="578" height="200" alt="image" src="https://github.com/user-attachments/assets/de34f3c6-165a-4c9b-a263-81e79b6c9b69" />


And a lower miter limit (like 1) would bevel all corners:

<img width="578" height="200" alt="image" src="https://github.com/user-attachments/assets/07c89e18-82ad-42a8-905f-083af799c401" />
