### PR TITLE
test: remove `it.only()` causing only a single test to run

### DIFF
--- a/test/unit/Transformer-test.ts
+++ b/test/unit/Transformer-test.ts
@@ -5142,7 +5142,7 @@ describe('Transformer', function () {
     );
   });
 
-  it.only('should handle transformation when node is not on stage (case for node destroy)', function () {
+  it('should handle transformation when node is not on stage (case for node destroy)', function () {
     var stage = addStage();
     var layer = new Konva.Layer();
     stage.add(layer);


### PR DESCRIPTION
Noticed that not all tests are running locally or in CI. [1] Just a specific test for `Transformer`.

[Turns out, `.only()` causes all other tests to be skipped.](https://mochajs.org/#exclusive-tests)

[1] Eg, https://github.com/konvajs/konva/actions/runs/17055670545/job/48352725937

<img width="1303" height="680" alt="image" src="https://github.com/user-attachments/assets/a9b56c07-635b-4f1d-8217-df6b7b8cbd1c" />
