### PR TITLE
Fix config parameter modified by toKonvaCanvas

### DIFF
--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -228,7 +228,7 @@ export class Layer extends Container<Group | Shape> {
     }
   }
   _toKonvaCanvas(config) {
-    config = config || {};
+    config = { ...config };
     config.width = config.width || this.getWidth();
     config.height = config.height || this.getHeight();
     config.x = config.x !== undefined ? config.x : this.x();

--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -316,7 +316,7 @@ export class Stage extends Container<Layer> {
     return this.content;
   }
   _toKonvaCanvas(config) {
-    config = config || {};
+    config = { ...config };
 
     config.x = config.x || 0;
     config.y = config.y || 0;


### PR DESCRIPTION
# Problem

The `config` parameter will be modified by `toKonvaCanvas`. If width and height are not specified in config, this function will calculate them and assign them to the config parameter.

This will result in that if the user defines config as a constant and renders multiple canvases of different widths and heights at the same time, the rendering results of the later ones will be affected by the previous ones because the config parameters are modified by the previous ones and passed to the later ones. The following is a sample code:

```js
// common config
const config = { pixelRatio: 3, mimeType: 'image/png' }

// render first stage
const blob1 = await stage1.toBlob(config);

// output config, config has been modified
console.log(config);
// output may be { pixelRatio: 3, mimeType: 'image/png', x: 0, y: 0, width: 100, height: 100 }

// render second stage, config is wrong because include stage1 x/y/width/height, so blob2 is wrong
const blob2 = await stage2.toBlob(config);
```

# Root Cause

In `toKonvaCanvas`, `config` is modified directly.

```js
config.width = config.width || this.getWidth();
config.height = config.height || this.getHeight();
config.x = config.x !== undefined ? config.x : this.x();
config.y = config.y !== undefined ? config.y : this.y();
```

# Solution

We need a shallow copy

```js
config = { ...config };
```