### PR TITLE
Better types inferences for Rect attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ types
 out.png
 cmj
 .test-temp
+.history
 
 # Numerous always-ignore extensions
 *.diff

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -32,7 +32,8 @@ export interface ContainerConfig extends NodeConfig {
  */
 export abstract class Container<
   ChildType extends Node = Node,
-> extends Node<ContainerConfig> {
+  Config extends ContainerConfig = ContainerConfig
+> extends Node<Config> {
   children: Array<ChildType> = [];
 
   /**

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -26,7 +26,7 @@ export type ShapeConfigHandler<TTarget> = {
 export type LineJoin = 'round' | 'bevel' | 'miter';
 export type LineCap = 'butt' | 'round' | 'square';
 
-export interface ShapeConfig extends NodeConfig {
+export type ShapeConfig<Props extends Record<string, any> = {}> = NodeConfig<Props> & {
   fill?: string | CanvasGradient;
   fillPatternImage?: HTMLImageElement;
   fillPatternX?: number;

--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -154,7 +154,7 @@ export const stages: Stage[] = [];
  * });
  */
 
-export class Stage extends Container<Layer> {
+export class Stage extends Container<Layer, StageConfig> {
   content: HTMLDivElement;
   pointerPos: Vector2d | null;
   _pointerPositions: (Vector2d & { id?: number })[] = [];

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -151,6 +151,9 @@ class TweenEngine {
 }
 
 export interface TweenConfig extends NodeConfig {
+  easing?: typeof Easings[keyof typeof Easings];
+  yoyo?: boolean;
+  onReset?: Function;
   onFinish?: Function;
   onUpdate?: Function;
   duration?: number;
@@ -419,7 +422,7 @@ export class Tween {
       // after tweening  points of line we need to set original end
       const attrs = Tween.attrs[node._id][this._id];
       if (attrs.points && attrs.points.trueEnd) {
-        node.setAttr('points', attrs.points.trueEnd);
+        node.setAttr('points' as any, attrs.points.trueEnd);
       }
 
       if (this.onFinish) {

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1121,3 +1121,5 @@ export const Util = {
     }
   },
 };
+
+export type AnyString<T> = T | (string & {})

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -8,7 +8,7 @@ import type { GetSet } from '../types.ts';
 import type { Context } from '../Context.ts';
 import { getNumberOrArrayOfNumbersValidator } from '../Validators.ts';
 
-export interface RectConfig extends ShapeConfig {
+export type RectConfig<Props extends Record<string, any> = {}> = ShapeConfig<Props> & {
   cornerRadius?: number | number[];
 }
 
@@ -30,7 +30,7 @@ export interface RectConfig extends ShapeConfig {
  *   strokeWidth: 5
  * });
  */
-export class Rect extends Shape<RectConfig> {
+export class Rect<Props extends Record<string, any> = {}> extends Shape<RectConfig<Props>> {
   _sceneFunc(context: Context) {
     const cornerRadius = this.cornerRadius(),
       width = this.width(),


### PR DESCRIPTION
Changed the signature of `getAttr`, `getAttrs`, `setAttr` and `setAttrs` of the `Node` class.
- It would hint with typescript the proper attribute name.
- It also accepts any attribute name to be backward compatible.
- You can specify the type of the attribute per Node

I only did for Rect as it would end up in a big PR, I wanted to have a small example.