### PR TITLE
add setWindow method to Stage objects to facilitate popout window compatibility

### DIFF
--- a/src/DragAndDrop.ts
+++ b/src/DragAndDrop.ts
@@ -156,18 +156,20 @@ export const DD = {
       }
     });
   },
+  _attachListeners: function (targetWindow: Window) {
+    targetWindow.addEventListener('mouseup', DD._endDragBefore, true);
+    targetWindow.addEventListener('touchend', DD._endDragBefore, true);
+    targetWindow.addEventListener('touchcancel', DD._endDragBefore, true);
+
+    targetWindow.addEventListener('mousemove', DD._drag);
+    targetWindow.addEventListener('touchmove', DD._drag);
+
+    targetWindow.addEventListener('mouseup', DD._endDragAfter, false);
+    targetWindow.addEventListener('touchend', DD._endDragAfter, false);
+    targetWindow.addEventListener('touchcancel', DD._endDragAfter, false);
+  },
 };
 
 if (Konva.isBrowser) {
-  window.addEventListener('mouseup', DD._endDragBefore, true);
-  window.addEventListener('touchend', DD._endDragBefore, true);
-  // add touchcancel to fix this: https://github.com/konvajs/konva/issues/1843
-  window.addEventListener('touchcancel', DD._endDragBefore, true);
-
-  window.addEventListener('mousemove', DD._drag);
-  window.addEventListener('touchmove', DD._drag);
-
-  window.addEventListener('mouseup', DD._endDragAfter, false);
-  window.addEventListener('touchend', DD._endDragAfter, false);
-  window.addEventListener('touchcancel', DD._endDragAfter, false);
+  DD._attachListeners(window);
 }

--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -241,6 +241,12 @@ export class Stage extends Container<Layer, StageConfig> {
     }
     return this;
   }
+  setWindow(win){
+    if (win) {
+      DD._attachListeners(win);
+    }
+    return this;
+  }
   shouldDrawHit() {
     return true;
   }


### PR DESCRIPTION
Fixes #1980

See https://github.com/RajRai/react-konva-dockview-example/commit/a102414ad3b529bdb653bc6e3a6d4de98bbdc237 for usage in a `react-konva` and `dockview-react` application