### PR TITLE
Support for fuzzed canvas browsers

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -143,7 +143,7 @@ interface ExtendedCanvasRenderingContext2D extends CanvasRenderingContext2D {
  */
 export class Context {
   canvas: Canvas;
-  _context: CanvasRenderingContext2D;
+  _context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   traceArr: Array<string>;
 
   constructor(canvas: Canvas) {
@@ -815,7 +815,7 @@ type CanvasContextProps = Pick<
   (typeof CONTEXT_PROPERTIES)[number]
 >;
 
-export interface Context extends CanvasContextProps {}
+export interface Context extends CanvasContextProps { }
 
 CONTEXT_PROPERTIES.forEach(function (prop) {
   Object.defineProperty(Context.prototype, prop, {
@@ -978,7 +978,7 @@ export class HitContext extends Context {
     super(canvas);
     this._context = canvas._canvas.getContext('2d', {
       willReadFrequently: true,
-    }) as CanvasRenderingContext2D;
+    }) as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   }
   _fill(shape: Shape) {
     this.save();

--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -3,7 +3,7 @@ import type { ContainerConfig } from './Container.ts';
 import { Container } from './Container.ts';
 import { Node } from './Node.ts';
 import { Factory } from './Factory.ts';
-import { SceneCanvas, HitCanvas } from './Canvas.ts';
+import { SceneCanvas, HitCanvas, isCanvasFarblingActive } from './Canvas.ts';
 import type { Stage } from './Stage.ts';
 import { getBooleanValidator } from './Validators.ts';
 
@@ -368,7 +368,13 @@ export class Layer extends Container<Group | Shape> {
 
     // fully opaque pixel
     if (p3 === 255) {
-      const colorKey = Util._rgbToHex(p[0], p[1], p[2]);
+      let colorKey = Util._rgbToHex(p[0], p[1], p[2]);
+      if (isCanvasFarblingActive()) {
+        const r = (p[0] & 0xfc).toString(16);
+        const g = (p[1] & 0xfc).toString(16);
+        const b = (p[2] & 0xfc).toString(16);
+        colorKey = '#' + r + g + b;
+      }
       const shape = shapes[HASH + colorKey];
       if (shape) {
         return {

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -16,6 +16,7 @@ import { _registerNode } from './Global.ts';
 import * as PointerEvents from './PointerEvents.ts';
 
 import type { GetSet, Vector2d } from './types.ts';
+import { isCanvasFarblingActive } from './Canvas.ts';
 import type { HitCanvas, SceneCanvas } from './Canvas.ts';
 
 // hack from here https://stackoverflow.com/questions/52667959/what-is-the-purpose-of-bivariancehack-in-typescript-types/52668133#52668133
@@ -207,6 +208,12 @@ export class Shape<
     while (true) {
       key = Util.getRandomColor();
       if (key && !(key in shapes)) {
+        if (isCanvasFarblingActive()) {
+          const r = (parseInt(key.slice(1, 3), 16) & 0xfc).toString(16);
+          const g = (parseInt(key.slice(3, 5), 16) & 0xfc).toString(16);
+          const b = (parseInt(key.slice(5, 7), 16) & 0xfc).toString(16);
+          key = '#' + r + g + b;
+        }
         break;
       }
     }
@@ -284,13 +291,13 @@ export class Shape<
         const matrix =
           typeof DOMMatrix === 'undefined'
             ? {
-                a: m[0], // Horizontal scaling. A value of 1 results in no scaling.
-                b: m[1], // Vertical skewing.
-                c: m[2], // Horizontal skewing.
-                d: m[3],
-                e: m[4], // Horizontal translation (moving).
-                f: m[5], // Vertical translation (moving).
-              }
+              a: m[0], // Horizontal scaling. A value of 1 results in no scaling.
+              b: m[1], // Vertical skewing.
+              c: m[2], // Horizontal skewing.
+              d: m[3],
+              e: m[4], // Horizontal translation (moving).
+              f: m[5], // Vertical translation (moving).
+            }
             : new DOMMatrix(m);
 
         pattern.setTransform(matrix);

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -530,8 +530,19 @@ export const Util = {
     // on some environments canvas.style is readonly
     try {
       (canvas as any).style = canvas.style || {};
-    } catch (e) {}
+    } catch (e) { }
     return canvas;
+  },
+  createOffscreenCanvas(width: number, height: number) {
+    ensureBrowser();
+    if (typeof OffscreenCanvas !== 'undefined') {
+      return new OffscreenCanvas(width, height);
+    } else {
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      return canvas;
+    }
   },
   createImageElement() {
     ensureBrowser();
@@ -1031,7 +1042,7 @@ export const Util = {
         topRight =
         bottomLeft =
         bottomRight =
-          Math.min(cornerRadius, width / 2, height / 2);
+        Math.min(cornerRadius, width / 2, height / 2);
     } else {
       topLeft = Math.min(cornerRadius[0] || 0, width / 2, height / 2);
       topRight = Math.min(cornerRadius[1] || 0, width / 2, height / 2);

--- a/src/canvas-backend.ts
+++ b/src/canvas-backend.ts
@@ -26,6 +26,14 @@ Konva.Util['createCanvasElement'] = () => {
   return node;
 };
 
+Konva.Util['createOffscreenCanvas'] = (width, height) => {
+  const node = canvas.createCanvas(width, height) as any;
+  if (!node['style']) {
+    node['style'] = {};
+  }
+  return node;
+};
+
 // create image in Node env
 Konva.Util.createImageElement = () => {
   const node = new canvas.Image() as any;

--- a/src/skia-backend.ts
+++ b/src/skia-backend.ts
@@ -25,6 +25,19 @@ Konva.Util['createCanvasElement'] = () => {
   return node;
 };
 
+Konva.Util['createOffscreenCanvas'] = (width, height) => {
+  const node = new Canvas(width, height) as any;
+  if (!node['style']) {
+    node['style'] = {};
+  }
+  node.toString = () => '[object OffscreenCanvas]';
+  const ctx = node.getContext('2d');
+  Object.defineProperty(ctx, 'canvas', {
+    get: () => node,
+  });
+  return node;
+};
+
 // create image in Node env
 Konva.Util.createImageElement = () => {
   const node = new Image() as any;


### PR DESCRIPTION
Brave, Tor, Safari in private mode, and other browsers implement canvas fuzzing. To work around this, this PR strips the hit detection canvas rendering to 6 bits instead of 8 for the colors (but only if fuzzing is detected). In practice, this limits the hit canvas to just over 262k objects, but the current implementation relies on a random color generator, so one would likely run into an issue with color generation due to the random generator long before the 250k object number would be hit anyways. It would be better to switch to a predictable color generator instead to ensure smooth generation for large numbers of shapes, but as it hasn't been an issue leaving the random generator.

This implementation also switches the HitCanvas to an OffscreenCanvas instead of adding an element to the DOM. It's unclear from the documentation if OffscreenCanvas is also affected by fuzzing, but it might not be.

Fixes #1928
Fixes #1769
Fixes #1132
Fixes #1619
Fixes #1484
Fixes #1195
Fixes #1151