### PR TITLE
Fix ValidatorFunc Type Mistake

### DIFF
--- a/src/Factory.ts
+++ b/src/Factory.ts
@@ -41,7 +41,7 @@ type Value<T extends Constructor, U extends Attr<T>> = ExtractGetSet<
 /**
  * A function that validates a value.
  */
-type ValidatorFunc<T> = (val: ExtractGetSet<T>, attr: string) => T;
+type ValidatorFunc<T> = (val: T, attr: string) => T;
 
 /**
  * Extracts the "components" (keys) of a GetSet value. The value must be an object.


### PR DESCRIPTION
The `ValidatorFunc` defined in Factory.ts has a mistake.

For Example:

```ts
addGetterSetter<T extends Constructor, U extends Attr<T>>(
    constructor: T,
    attr: U,
    def?: Value<T, U>,
    validator?: ValidatorFunc<Value<T, U>>,
    after?: AfterFunc<T>
)
```
because `Value<T, U>` has do `ExtractGetSet `：
```ts
type Value<T extends Constructor, U extends Attr<T>> = ExtractGetSet<InstanceType<T>[U]>
```
but  `ValidatorFunc` do `ExtractGetSet` again:
```ts
type ValidatorFunc<T> = (val: ExtractGetSet<T>, attr: string) => T;
```
so, the val is always `never`, and with VSCode can see this phenomenon：

<img width="1097" height="280" alt="image" src="https://github.com/user-attachments/assets/3d767a5d-a81d-4cab-89a5-873b1780f158" />

my change can fix this mistake:

<img width="1053" height="277" alt="image" src="https://github.com/user-attachments/assets/6720af46-5dc0-40b3-ad97-a28676c30cbe" />
