### PR TITLE
fix: correct requestAnimationFrame fallback timing

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -429,7 +429,7 @@ var OBJECT_ARRAY = '[object Array]',
 const req =
   (typeof requestAnimationFrame !== 'undefined' && requestAnimationFrame) ||
   function (f) {
-    setTimeout(f, 60);
+    setTimeout(f, 16);  // 60fps ≈ 16.67ms per frame
   };
 /**
  * @namespace Util


### PR DESCRIPTION
## Problem
The `requestAnimationFrame` fallback uses `setTimeout(f, 60)`, which results in ~16.7fps instead of the intended 60fps.

## Solution
Changed the timeout from 60ms to 16ms (1000ms / 60 ≈ 16.67ms).

## Impact
Only affects browsers that don't support `requestAnimationFrame` (very rare in modern browsers), but this fix ensures correct behavior for edge cases.