### PR TITLE
perf(Text): hoist stringToArray(line) out of _setTextData binary search

### DIFF
--- a/src/shapes/Text.ts
+++ b/src/shapes/Text.ts
@@ -609,18 +609,22 @@ export class Text extends Shape<TextConfig> {
          * break the line into multiple fitting lines
          */
         while (line.length > 0) {
+          // Compute the grapheme array once per iteration. `line` is constant
+          // within this block (only reassigned at the bottom), so calling
+          // `stringToArray(line)` inside the binary search and again afterwards
+          // is redundant and makes resize O(N·logN) on long text.
+          const lineArray = stringToArray(line);
           /*
            * use binary search to find the longest substring that
            * that would fit in the specified width
            */
           let low = 0,
-            high = stringToArray(line).length, // Convert to array for proper emoji handling
+            high = lineArray.length, // Convert to array for proper emoji handling
             match = '',
             matchWidth = 0;
           while (low < high) {
             const mid = (low + high) >>> 1,
               // Convert array indices to string
-              lineArray = stringToArray(line),
               substr = lineArray.slice(0, mid + 1).join(''),
               substrWidth = this._getTextWidth(substr);
 
@@ -652,7 +656,6 @@ export class Text extends Shape<TextConfig> {
             // a fitting substring was found
             if (wrapAtWord) {
               // try to find a space or dash where wrapping could be done
-              const lineArray = stringToArray(line);
               const matchArray = stringToArray(match);
               const nextChar = lineArray[matchArray.length];
               const nextIsSpaceOrDash = nextChar === SPACE || nextChar === DASH;
@@ -691,8 +694,7 @@ export class Text extends Shape<TextConfig> {
               break;
             }
 
-            // Convert remaining text using array operations
-            const lineArray = stringToArray(line);
+            // Reuse the cached `lineArray` to compute the remaining text.
             line = lineArray.slice(low).join('').trimLeft();
 
             if (line.length > 0) {


### PR DESCRIPTION
_Disclaimer: The fix and the description below is AI generated after it analyzed a performance trace. The trace covered the resizing operation of a bigger chunk of text. I currently patch this performance issue in user land but would appreciate if it could get fixed upstream. Thanks for this great library!_

#### Problem

Resizing a `Konva.Text` node via `Transformer` is **smooth on short text but progressively slower the longer the text gets**, to the point of being unusable on multi-line paragraphs even on fast machines. Setting `width` (which Transformer-driven resize does on every `mousemove`) calls `_setTextData`, and most of that call is wasted work.

#### Root cause

Inside `_setTextData`'s binary search, `stringToArray(line)` is called on **every** iteration:

```ts
while (low < high) {
  const mid = (low + high) >>> 1,
    lineArray = stringToArray(line),                  // ← O(N) per iteration
    substr = lineArray.slice(0, mid + 1).join(''),
    substrWidth = this._getTextWidth(substr);
  …
}
```

`line` is constant within this block (it's only reassigned at the bottom of the outer `while (line.length > 0)`), so the call is redundant. `stringToArray` itself is `O(N)` because it iterates with five `\p{…}` Unicode-property regex tests per character.

Per outer iteration this gives:

- log₂(N) + 1 calls in the binary search
- +1 call for `stringToArray(line)` in the `wrapAtWord` branch
- +1 call for `stringToArray(line)` to compute the remaining text

Total: `O(N · log N)` per `_setTextData`, and `_setTextData` runs on **every mousemove** during a transformer-driven width resize. On a 120 Hz pointer with a few hundred characters of wrapped text, this saturates the main thread.

#### Profiling evidence (real-world editor with ~1 KB of wrapped text)

Across four `_handleMouseMove` events during a single drag (from a Chrome DevTools Performance trace):

| Function (total time across 4 ticks) | Time |
|---|---|
| `_handleMouseMove` | 1391 ms |
| → `Transformer._fitNodesInto` → user `transform` handler | 1390 ms |
| → `setAttrs` → `_setTextData` | 1389 ms |
| → **`stringToArray` self time** | **1387 ms** |

i.e. ~350 ms of `stringToArray` per mousemove, all of it redundant.

#### Regression history

The redundancy was introduced in **Konva 7.1.1** by [4b696317](https://github.com/konvajs/konva/commit/4b696317823e33bd26d43d6388f4797ba8839136) — *"Better unicode support in `Konva.Text` and `Konva.TextPath`. Emoji should work better now 👍 fix #690"*. Before that commit, `_setTextData` indexed into `line` directly with `line.length` / `line.slice` (O(1) per binary-search step). When grapheme-aware splitting was added, `stringToArray(line)` was inserted in place of the index-based access without hoisting it out of the loop. The grapheme correctness is desirable; the per-iteration cost is not.

#### Fix

Hoist `stringToArray(line)` to once per outer iteration of `while (line.length > 0)` and reuse the cached `lineArray` for the binary search, the `wrapAtWord` `lineArray[matchArray.length]` lookup, and the remaining-text slice. **Algorithm and output are unchanged.**

The `stringToArray(match)` call inside `wrapAtWord` is intentionally preserved — `match` is short and that branch only runs once per produced wrap line.

#### Verification

- `npm run tsc` — clean
- `npm run test:node:canvas` — **793 passing, 17 pending** (all pre-existing). The text test suite covers wrap-at-word, wrap-at-char, ellipsis, emoji clusters, RTL, fixed width/height, and `getClientRect` — none changed.
- Manual: Konva-based editor with multi-line paragraph nodes; transformer-resize is smooth at 120 Hz; long-text editing no longer blocks the main thread.
