### PR TITLE
fix(Path): getPointAtLength returns a valid point past the end of a closed path

### DIFF
--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -251,7 +251,11 @@ export class Path extends Shape<PathConfig> {
     }
 
     if (i === ii) {
-      points = dataArray[i - 1].points.slice(-2);
+      let j = i - 1;
+      while (j > 0 && dataArray[j].points.length < 2) {
+        j--;
+      }
+      points = dataArray[j].points.slice(-2);
       return {
         x: points[0],
         y: points[1],

--- a/test/unit/Path-test.ts
+++ b/test/unit/Path-test.ts
@@ -604,6 +604,23 @@ describe('Path', function () {
   });
 
   // ======================================================
+  it('getPointAtLength returns a valid point past the end of a closed path', function () {
+    var path = new Konva.Path({
+      data: 'M0,0 L100,0 L100,100 z',
+    });
+
+    var total = path.getLength();
+
+    // a length past the end of the path (e.g. from floating point drift while
+    // animating along the path) must still return a real point, as it does for
+    // open paths, not { x: undefined, y: undefined }
+    var point = path.getPointAtLength(total + 500);
+
+    assert.equal(point.x, 100);
+    assert.equal(point.y, 100);
+  });
+
+  // ======================================================
   it('Tiger (RAWR!)', function () {
     this.timeout(5000);
     var stage = addStage();


### PR DESCRIPTION
`Path.getPointAtLength(length)` returns `{x: undefined, y: undefined}` when `length` is past the total length of a closed path (data ending in `z`/`Z`).

```js
const path = new Konva.Path({ data: 'M0,0 L100,0 L100,100 z' }); // total length 200
path.getPointAtLength(200.0001); // { x: undefined, y: undefined }  (open paths return the last point)
```

For an open path the same query correctly returns the last vertex. This is hit routinely when animating a marker along a path, because floating-point drift pushes the requested length a hair past `getLength()`, and the undefined coordinates then flow into position setters, placing the node at `(NaN, NaN)`.

## Cause

`parsePathData` stores the closing `z` as a segment with an empty `points` array and `pathLength: 0`. In `getPointAtLengthOfDataArray`, when `length` exceeds the total, the loop steps to `i === ii` and the fallback reads `dataArray[i - 1].points.slice(-2)`; for a closed path that previous segment is the coordinate-less `z`, so `points[0]`/`points[1]` are `undefined`.

## Fix

Walk back over trailing segments that carry no coordinates (the `z` close) to the last actually-drawn point, matching the open-path behavior.

## Testing

Added a test in `test/unit/Path-test.ts` querying past the end of a closed path; it returns `{undefined, undefined}` on the current code and the last point with the fix. The existing `getPointAtLength` regression test still passes.
