### PR TITLE
fix: Arc.getSelfRect() reports a full circle for angle: 0, clockwise: true

### DIFF
--- a/src/shapes/Arc.ts
+++ b/src/shapes/Arc.ts
@@ -66,6 +66,27 @@ export class Arc extends Shape<ArcConfig> {
     const innerRadius = this.innerRadius();
     const outerRadius = this.outerRadius();
     const clockwise = this.clockwise();
+
+    // a raw angle that is a non-zero multiple of a full turn is a degenerate case:
+    // _sceneFunc draws it with `context.arc(0, 0, r, 0, angle, clockwise)`, and per
+    // the canvas spec that only sweeps a full circle when the turn direction implied
+    // by the angle's sign matches `clockwise` (native `counterclockwise` flag) -
+    // otherwise it's a zero-length arc, same as angle === 0. The 360 - angle flip
+    // below can't tell these two outcomes apart (it always lands on 0 or 2*PI), so
+    // it must be special-cased here instead of falling through to the trig formula.
+    const rawAngle = Konva.getAngle(this.angle());
+    if (rawAngle % (Math.PI * 2) === 0) {
+      const isFullCircle = rawAngle !== 0 && rawAngle > 0 !== clockwise;
+      return isFullCircle
+        ? {
+            x: -outerRadius,
+            y: -outerRadius,
+            width: outerRadius * 2,
+            height: outerRadius * 2,
+          }
+        : { x: innerRadius, y: 0, width: outerRadius - innerRadius, height: 0 };
+    }
+
     const angle = Konva.getAngle(clockwise ? 360 - this.angle() : this.angle());
 
     const boundLeftRatio = Math.cos(Math.min(angle, Math.PI));

--- a/test/unit/Arc-test.ts
+++ b/test/unit/Arc-test.ts
@@ -172,6 +172,56 @@ describe('Arc', function () {
     });
   });
 
+  it('getSelfRect on zero angle clockwise arc should be degenerate, not a full circle', function () {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+    var arc = new Konva.Arc({
+      x: 100,
+      y: 100,
+      innerRadius: 30,
+      outerRadius: 80,
+      angle: 0,
+      clockwise: true,
+    });
+
+    layer.add(arc);
+    stage.add(layer);
+
+    // an angle of 0 draws nothing (context.arc with startAngle === endAngle),
+    // same as the counter-clockwise case below - it must not be reported as
+    // a full circle just because the 360 - angle flip used internally for
+    // clockwise arcs lands on 2*PI.
+    assertAlmostDeepEqual(arc.getSelfRect(), {
+      x: 30,
+      y: 0,
+      width: 50,
+      height: 0,
+    });
+  });
+
+  it('getSelfRect on zero angle counter-clockwise arc matches the clockwise case', function () {
+    var stage = addStage();
+    var layer = new Konva.Layer();
+    var arc = new Konva.Arc({
+      x: 100,
+      y: 100,
+      innerRadius: 30,
+      outerRadius: 80,
+      angle: 0,
+      clockwise: false,
+    });
+
+    layer.add(arc);
+    stage.add(layer);
+
+    assertAlmostDeepEqual(arc.getSelfRect(), {
+      x: 30,
+      y: 0,
+      width: 50,
+      height: 0,
+    });
+  });
+
   it('cache', function () {
     var stage = addStage();
     var layer = new Konva.Layer();


### PR DESCRIPTION
An `Arc` with `angle: 0` (the default) and `clockwise: true` draws nothing - it's `context.arc(0, 0, r, 0, 0, true)`, a zero-length arc, same as `clockwise: false`. But `getSelfRect()` was returning a full `outerRadius*2` square for it instead of a degenerate rect.

The cause is the `clockwise ? 360 - angle : angle` flip the function uses internally: at `angle: 0` that becomes `360`, which then hits the trig formula's full-circle branch. Since this only happens for the clockwise direction, any newly created Arc with the default angle and `clockwise: true` reports a bounding box way bigger than what actually renders.

Added a couple of tests comparing both directions at `angle: 0` so they can't drift apart again.