### PR TITLE
fix(Shape): respect imageSmoothingEnabled for fillPatternImage

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -842,6 +842,18 @@ export class SceneContext extends Context {
     shape._fillFunc(this);
   }
   _fillPattern(shape: Shape) {
+    // `imageSmoothingEnabled` (set on the layer/context) controls pattern
+    // smoothing in the browser. node-canvas ignores it for pattern fills and
+    // instead exposes a non-standard `patternQuality` property, so mirror the
+    // current smoothing setting onto it to keep both backends consistent.
+    const context = this._context as CanvasRenderingContext2D & {
+      patternQuality?: string;
+    };
+    if ('patternQuality' in context) {
+      context.patternQuality = context.imageSmoothingEnabled
+        ? 'good'
+        : 'nearest';
+    }
     this.setAttr('fillStyle', shape._getFillPattern());
     shape._fillFunc(this);
   }

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -656,6 +656,10 @@ export class Shape<
         bufferContext.clear();
       }
       bufferContext.save();
+      // the buffer canvas is a separate context that does not inherit the
+      // destination `imageSmoothingEnabled` flag, so propagate it to keep
+      // pattern/image smoothing consistent with the target context.
+      bufferContext.imageSmoothingEnabled = context.imageSmoothingEnabled;
       bufferContext._applyLineJoin(this);
       bufferContext._applyMiterLimit(this);
       // layer might be undefined if we are using cache before adding to layer

--- a/test/unit/Shape-test.ts
+++ b/test/unit/Shape-test.ts
@@ -303,6 +303,71 @@ describe('Shape', function () {
   });
 
   // ======================================================
+  it('fillPatternImage should respect imageSmoothingEnabled', function () {
+    // build a tiny 2x2 checker pattern (white / black)
+    const patternCanvas = Konva.Util.createCanvasElement();
+    patternCanvas.width = 2;
+    patternCanvas.height = 2;
+    const pctx = patternCanvas.getContext('2d')!;
+    pctx.fillStyle = 'black';
+    pctx.fillRect(0, 0, 2, 2);
+    pctx.fillStyle = 'white';
+    pctx.fillRect(0, 0, 1, 1);
+    pctx.fillRect(1, 1, 1, 1);
+
+    // scan a horizontal row of the rendered pattern and collect the
+    // R channel values of the pixels that sit around a source-pixel boundary
+    function renderRow(smoothing: boolean) {
+      const stage = addStage();
+      const layer = new Konva.Layer({ imageSmoothingEnabled: smoothing });
+      stage.add(layer);
+      const rect = new Konva.Rect({
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 120,
+        fillPatternImage: patternCanvas,
+        fillPatternScaleX: 40,
+        fillPatternScaleY: 40,
+      });
+      layer.add(rect);
+      layer.draw();
+
+      const ctx = layer.getCanvas().getContext()._context;
+      const pr = layer.getCanvas().getPixelRatio();
+      const y = Math.floor(1 * pr);
+      const width = Math.floor(100 * pr);
+      const data = ctx.getImageData(0, y, width, 1).data;
+      const reds: number[] = [];
+      for (let i = 0; i < width; i++) {
+        reds.push(data[i * 4]);
+      }
+      return reds;
+    }
+
+    // when smoothing is disabled every pixel must be a pure source pixel:
+    // either fully white (255) or fully black (0), never a blended value.
+    const sharpReds = renderRow(false);
+    const blended = sharpReds.filter((r) => r > 20 && r < 235);
+    assert.equal(
+      blended.length,
+      0,
+      'with imageSmoothingEnabled=false pattern must not be blurred, got blended pixels: ' +
+        blended.join(',')
+    );
+
+    // sanity: with smoothing enabled the same scaled pattern IS blurred,
+    // so blended pixels should appear around the boundaries.
+    const smoothReds = renderRow(true);
+    const smoothBlended = smoothReds.filter((r) => r > 20 && r < 235);
+    assert.isAbove(
+      smoothBlended.length,
+      0,
+      'with imageSmoothingEnabled=true the scaled pattern should be blurred'
+    );
+  });
+
+  // ======================================================
   it('set image fill to color then image then linear gradient then back to image', function (done) {
     loadImage('darth-vader.jpg', (imageObj) => {
       var stage = addStage();


### PR DESCRIPTION
## What

Makes `fillPatternImage` respect `imageSmoothingEnabled`. Previously a pattern fill always rendered smoothed, ignoring the shape/layer `imageSmoothingEnabled` setting.

## Why

Two paths were dropping the flag:

1. **node-canvas** ignores `imageSmoothingEnabled` for pattern fills entirely and uses a non-standard `patternQuality` property instead, so the plain draw path never honored the flag on the node backend.
2. The **buffer-canvas path** (fill + stroke + opacity, or shadow) draws into the shared `stage.bufferCanvas` context, which never inherited the destination context's `imageSmoothingEnabled` — so patterns drawn via the buffer were always smoothed, including in the browser.

## How (2 source edits, ~16 lines)

- `src/Context.ts` `SceneContext._fillPattern`: mirror the context's `imageSmoothingEnabled` onto `patternQuality` (`'good'`/`'nearest'`), guarded by `'patternQuality' in context` so it is a no-op in browsers.
- `src/Shape.ts` `drawScene` buffer branch: propagate `bufferContext.imageSmoothingEnabled = context.imageSmoothingEnabled` inside the existing save/restore (no state leak).

## Testing

- Added `fillPatternImage should respect imageSmoothingEnabled` in `test/unit/Shape-test.ts`; confirmed it fails before (blended boundary pixels) and passes after (pure 0/255 with smoothing off).
- Verified the buffer path end-to-end (fill+stroke+opacity): 0 blended pixels with smoothing off, present with smoothing on.
- Full node suite: 804 passing, 0 failing. `tsc --noEmit` clean.

Closes #1958
