### PR TITLE
fix(Util): preserve alpha of the named color "transparent"

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -747,7 +747,7 @@ export const Util = {
       r: c[0],
       g: c[1],
       b: c[2],
-      a: 1,
+      a: c.length > 3 ? c[3] : 1,
     };
   },
   // Parse rgb(n, n, n)

--- a/test/unit/Util-test.ts
+++ b/test/unit/Util-test.ts
@@ -113,6 +113,22 @@ describe('Util', function () {
     });
   });
 
+  it('colorToRGBA() - named color transparent keeps its alpha', function () {
+    assert.deepEqual(Konva.Util.colorToRGBA('transparent'), {
+      r: 255,
+      g: 255,
+      b: 255,
+      a: 0,
+    });
+
+    assert.deepEqual(Konva.Util.colorToRGBA('red'), {
+      r: 255,
+      g: 0,
+      b: 0,
+      a: 1,
+    });
+  });
+
   it('make sure Transform is exported', () => {
     assert.equal(!!Konva.Transform, true);
   });


### PR DESCRIPTION
### Problem

`Konva.Util.colorToRGBA('transparent')` returns an **opaque** color:

```js
Konva.Util.colorToRGBA('transparent');
// { r: 255, g: 255, b: 255, a: 1 }   ← a should be 0
```

The named-color table already defines it correctly with a zero alpha:

```js
// src/Util.ts
transparent: [255, 255, 255, 0],
```

but `_namedColorToRBA` hard-codes `a: 1` and ignores the fourth element:

```js
return { r: c[0], g: c[1], b: c[2], a: 1 };
```

Every other parser honors alpha — `#0000` and `rgba(0,0,0,0)` both correctly
return `a: 0`. Named colors are the only branch that drops it, and
`transparent` is the only named color that carries a non-1 alpha, so it is the
one value this branch gets wrong.

### Impact

`colorToRGBA` feeds `Tween` color interpolation (fill / stroke / shadowColor).
Tweening **to or from `'transparent'`** — the canonical fade in/out idiom —
computes an alpha delta of `1 - 1 = 0`, so the shape never fades; it snaps to
fully opaque **white** `(255, 255, 255)` instead of fading out.

### Fix

Honor the alpha in the color table, mirroring the hex/rgba parsers:

```js
a: c.length > 3 ? c[3] : 1,
```

### Test

Added a `colorToRGBA()` case asserting `transparent → a: 0` (and `red → a: 1`
so the default-alpha path stays covered). Fails on `master`, passes with the fix.
